### PR TITLE
support ssb-tribes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,3597 @@
 {
   "name": "ssb-fixtures",
-  "version": "2.1.0",
-  "lockfileVersion": 1,
+  "version": "2.2.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "implausible": "3.0.4",
+        "lorem-ipsum": "2.0.3",
+        "mkdirp": "^1.0.4",
+        "monotonic-timestamp": "staltz/mock-monotonic-timestamp",
+        "promisify-4loc": "1.0.0",
+        "rimraf": "^3.0.2",
+        "scuttle-testbot": "1.5.0",
+        "secret-stack": "6.3.1",
+        "ssb-backlinks": "2.1.1",
+        "ssb-caps": "1.1.0",
+        "ssb-config": "3.4.5",
+        "ssb-db": "20.3.0",
+        "ssb-keys": "8.0.0",
+        "ssb-logging": "1.0.0",
+        "ssb-master": "1.0.3",
+        "ssb-private1": "1.0.1",
+        "ssb-query": "2.4.5",
+        "ssb-tribes": "^2.0.1",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "ssb-fixtures": "lib/bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^14.14.2",
+        "flumecodec": "^0.0.1",
+        "flumedb": "^2.1.8",
+        "flumelog-offset": "^3.4.4",
+        "pull-stream": "3.6.14",
+        "ssb-ref": "2.14.2",
+        "ssb-typescript": "^2.1.0",
+        "tap-bail": "^1.0.0",
+        "tap-spec": "^5.0.0",
+        "tape": "^5.0.1",
+        "typescript": "^4.0.3"
+      }
+    },
+    "node_modules/@tangle/graph": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@tangle/graph/-/graph-2.1.0.tgz",
+      "integrity": "sha512-Jx4W39lLjAAd13Rh7+m8Yi742NVp1kbbz6W4sv/jPStb/K/+0nj4Rafe3jW9EkazInrTXtQAuY7VEAeVaYmEew==",
+      "dependencies": {
+        "lodash.clone": "^4.5.0",
+        "lodash.set": "^4.3.2"
+      }
+    },
+    "node_modules/@tangle/linear-append": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tangle/linear-append/-/linear-append-1.0.0.tgz",
+      "integrity": "sha512-fZh+o7JfLTVt+VefmSk4ROjlJtoWYVedM2+29Xgnigli5tztmh+2wYqcW6fB7ivckHW3OtNWgKDHJzDiOqaybA==",
+      "dependencies": {
+        "is-my-json-valid": "^2.20.5"
+      }
+    },
+    "node_modules/@tangle/overwrite": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tangle/overwrite/-/overwrite-2.0.1.tgz",
+      "integrity": "sha512-PyV+LGXKVJrN3MHU6suRJNmDZxUJKOw8fU3w0lMykmUOjHKooFw0fkXYqLLhR3u6scfZP1ECi+TXQtIy6b4kOQ==",
+      "dependencies": {
+        "is-my-json-valid": "^2.20.5",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
+    "node_modules/@tangle/reduce": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tangle/reduce/-/reduce-3.1.0.tgz",
+      "integrity": "sha512-FonAaam87HgJ1d9qXDqnbyRdRzIObM7UmhsdpD+2RTuvdl6Eu9UyNkkU9jqAX5r2elgfYAUgKYQ8KJ9XDw9xYg==",
+      "dependencies": {
+        "@tangle/graph": "^2.1.0"
+      }
+    },
+    "node_modules/@tangle/strategy": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tangle/strategy/-/strategy-2.0.1.tgz",
+      "integrity": "sha512-zQcdCXLbNAWH28VStWNR7bLV/gakjBgdi0KXlc/kRH8JB2+HXfz2jCVVsEzb5H6pGhZuJ7GMjI7wJgnMbvldxw==",
+      "dependencies": {
+        "is-my-json-valid": "^2.20.5",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
+      "dev": true
+    },
+    "node_modules/abstract-leveldown": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aligned-block-file": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.2.2.tgz",
+      "integrity": "sha512-2Sy0hWhifVb8ycNFJgicL8fDPL2Ct1r62XOVxXnykn36z22MPZwnQlCmB2viQlY/lwfuO67GaQjUZ0rJgdVP7Q==",
+      "dependencies": {
+        "hashlru": "^2.1.0",
+        "int53": "^1.0.0",
+        "mkdirp": "^0.5.1",
+        "obv": "^0.0.1",
+        "rwlock": "^5.0.0",
+        "uint48be": "^2.0.1"
+      }
+    },
+    "node_modules/aligned-block-file/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/append-batch": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.2.tgz",
+      "integrity": "sha1-1zm0UDiIJF1Hkz1HVisRSf+d+Lc="
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
+    "node_modules/async-single": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
+      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
+    },
+    "node_modules/atomic-file": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.1.1.tgz",
+      "integrity": "sha512-Eh6pW+fRC2/1RxPq3hO8+PkZKv+wujzKky2MP/n69eC8yMkbNFfuEb/riZHqf13M7gr6Hvglpk/kISgBSBb6bQ==",
+      "dependencies": {
+        "flumecodec": "0.0.1",
+        "idb-kv-store": "^4.5.0",
+        "mutexify": "^1.2.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dependencies": {
+        "array-filter": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "node_modules/base64-url": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.3.tgz",
+      "integrity": "sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/bash-color": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
+      "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
+    },
+    "node_modules/binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
+      "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "dev": true
+    },
+    "node_modules/buffer-xor": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/charwise": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
+      "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
+    },
+    "node_modules/chloride": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.1.tgz",
+      "integrity": "sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==",
+      "dependencies": {
+        "sodium-browserify": "^1.2.7",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "sodium-chloride": "^1.1.2"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^3.0.0"
+      }
+    },
+    "node_modules/chloride-test": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.4.tgz",
+      "integrity": "sha512-9vhoi1qXSBPn6//ZxIgSe3M2QhKHzIPZQzmrZgmPADsqW0Jxpe3db1e7aGSRUMXbxAQ04SfypdT8dGaSvIvKDw==",
+      "dependencies": {
+        "json-buffer": "^2.0.11"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.3.tgz",
+      "integrity": "sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/compare-at-paths": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/compare-at-paths/-/compare-at-paths-1.0.0.tgz",
+      "integrity": "sha512-Ke1ejo/RZ+Hzku4gcW34uPMOR4Cpq87MAotELgV9mwiAzDN726cu+eWo0zWg1vRIfyf6yK5bW9uIW+c/SksQ5w==",
+      "dependencies": {
+        "libnested": "^1.3.2",
+        "tape": "^4.9.1",
+        "typewiselite": "^1.0.0"
+      }
+    },
+    "node_modules/compare-at-paths/node_modules/is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/compare-at-paths/node_modules/object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/compare-at-paths/node_modules/resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/compare-at-paths/node_modules/tape": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
+      "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
+      "dependencies": {
+        "deep-equal": "~1.1.1",
+        "defined": "~1.0.0",
+        "dotignore": "~0.1.2",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.6",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "is-regex": "~1.0.5",
+        "minimist": "~1.2.5",
+        "object-inspect": "~1.7.0",
+        "resolve": "~1.17.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.2.1",
+        "through": "~2.3.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/cont": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
+      "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
+      "dependencies": {
+        "continuable": "~1.2.0",
+        "continuable-para": "~1.2.0",
+        "continuable-series": "~1.2.0"
+      }
+    },
+    "node_modules/continuable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz",
+      "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY="
+    },
+    "node_modules/continuable-hash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
+      "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
+      "dependencies": {
+        "continuable": "~1.1.6"
+      }
+    },
+    "node_modules/continuable-hash/node_modules/continuable": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+      "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
+    },
+    "node_modules/continuable-list": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
+      "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
+      "dependencies": {
+        "continuable": "~1.1.6"
+      }
+    },
+    "node_modules/continuable-list/node_modules/continuable": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+      "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
+    },
+    "node_modules/continuable-para": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
+      "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
+      "dependencies": {
+        "continuable-hash": "~0.1.4",
+        "continuable-list": "~0.1.5"
+      }
+    },
+    "node_modules/continuable-series": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
+      "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deferred-leveldown": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
+      "dependencies": {
+        "abstract-leveldown": "~6.2.1",
+        "inherits": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+    },
+    "node_modules/dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "ignored": "bin/ignored"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
+    "node_modules/ed2curve": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
+      "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
+      "dependencies": {
+        "tweetnacl": "0.x.x"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/encoding-down": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+      "dependencies": {
+        "abstract-leveldown": "^6.2.1",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/encoding-down/node_modules/level-codec": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/envelope-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/envelope-js/-/envelope-js-1.0.0.tgz",
+      "integrity": "sha512-Z0zHgYNMZIOqR6CehiPowBwzq9uB9ikcp2WexCiOGcBMOsfsB0dQR65VnVkqZnTFUmi9fGC1syptGEM1TULz7g==",
+      "dependencies": {
+        "buffer-xor": "^2.0.2",
+        "envelope-spec": "^1.0.0",
+        "futoin-hkdf": "^1.3.2",
+        "sodium-native": "^3.2.0"
+      }
+    },
+    "node_modules/envelope-spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/envelope-spec/-/envelope-spec-1.0.0.tgz",
+      "integrity": "sha512-NJ/neUZbvGgrq/cVmMZvNR58aypn3017/WIVIeOJCtMdREdkKa3G6tTMo40RqONNI3QyPtDocpBdtkbisHim2Q=="
+    },
+    "node_modules/errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
+    },
+    "node_modules/explain-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
+    },
+    "node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/flumecodec": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+      "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+      "dependencies": {
+        "level-codec": "^6.2.0"
+      }
+    },
+    "node_modules/flumedb": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-2.1.8.tgz",
+      "integrity": "sha512-MtBCZFjj9GuqOQP8Ld87FbXm8ztQyLkLeuiHuB5+aACFuVn1kunnCis75R03ujFZTqCFmkBwFz7E016b3DB0zA==",
+      "dependencies": {
+        "cont": "^1.0.3",
+        "explain-error": "^1.0.3",
+        "obz": "1.0.2",
+        "pull-abortable": "^4.1.1",
+        "pull-cont": "^0.1.1",
+        "pull-looper": "^1.0.0",
+        "pull-stream": "^3.6.14"
+      }
+    },
+    "node_modules/flumelog-offset": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.4.tgz",
+      "integrity": "sha512-sakCD+dVx541h3VeVq3Ti2lWPRrJf8PBRmnbm9EMBVLJnZkS3UD2lAlClZROxgKbh/JkMPyffvhDGv4VHNCVbA==",
+      "dependencies": {
+        "aligned-block-file": "^1.2.0",
+        "append-batch": "0.0.2",
+        "hashlru": "^2.3.0",
+        "int53": "^1.0.0",
+        "looper": "^4.0.0",
+        "obv": "0.0.1",
+        "pull-cursor": "^3.0.0",
+        "pull-looper": "^1.0.0",
+        "pull-stream": "^3.6.13",
+        "uint48be": "^2.0.1"
+      }
+    },
+    "node_modules/flumeview-level": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-4.0.4.tgz",
+      "integrity": "sha512-8C/o/oZU73ot1LMbxCyKeZJ0D3L5AGdxzIF5H2QtmznMSoZHVG1gT2IDjkOtesenVPlLQKnL95ewMKbE7cXWEw==",
+      "dependencies": {
+        "charwise": "^3.0.1",
+        "explain-error": "^1.0.4",
+        "level": "^6.0.1",
+        "ltgt": "^2.1.3",
+        "mkdirp": "^1.0.4",
+        "obz": "^1.0.2",
+        "pull-level": "^2.0.3",
+        "pull-paramap": "^1.2.1",
+        "pull-stream": "^3.6.14",
+        "pull-write": "^1.1.1"
+      }
+    },
+    "node_modules/flumeview-links": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/flumeview-links/-/flumeview-links-2.1.0.tgz",
+      "integrity": "sha512-VzqbNJ9qYE9eopCrhWXlPSoIoW4xanMy6YFyVSaYAwQIPoIZ+F1s1D3vmzOLXGhPesgHiXAlxmFSzXM5C9DKbQ==",
+      "dependencies": {
+        "deep-equal": "^2.0.3",
+        "flumeview-level": "^4.0.3",
+        "map-filter-reduce": "^3.2.2",
+        "pull-flatmap": "0.0.1",
+        "pull-stream": "^3.6.14"
+      }
+    },
+    "node_modules/flumeview-links/node_modules/deep-equal": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
+      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "es-get-iterator": "^1.1.1",
+        "get-intrinsic": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/flumeview-query": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-8.0.0.tgz",
+      "integrity": "sha512-uPTT5I26ePMc6Xhjebu1aiaHAd7P3EqyE9SZB6B9ZIvXtMXhFYNk7iO1yzh1ZXp3aYzdYmrI9k8mSz9urZ9gNQ==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "flumeview-level": "^4.0.3",
+        "map-filter-reduce": "^3.2.0",
+        "pull-flatmap": "0.0.1",
+        "pull-paramap": "^1.1.3",
+        "pull-sink-through": "0.0.0",
+        "pull-stream": "^3.4.0"
+      }
+    },
+    "node_modules/flumeview-reduce": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.17.tgz",
+      "integrity": "sha512-Li09TntlRpN51GtFKllIh5nDdBcyDazvi5a/yvbdUCS9xAFb8OA6H6uu32W9gG+4GyvfUi9AsOyN8RQ8OcREQA==",
+      "dependencies": {
+        "async-single": "^1.0.5",
+        "atomic-file": "^2.0.0",
+        "deep-equal": "^1.0.1",
+        "flumecodec": "0.0.0",
+        "obv": "0.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-stream": "^3.5.0"
+      }
+    },
+    "node_modules/flumeview-reduce/node_modules/flumecodec": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
+      "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
+      "dependencies": {
+        "level-codec": "^6.2.0"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/futoin-hkdf": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.3.tgz",
+      "integrity": "sha512-oR75fYk3B3X9/B02Y6vusrBKucrpC6VjxhRL+C6B7FwUpuSRHbhBNG3AZbcE/xPyJmEQWsyqUFp3VeNNbA3S7A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-network2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/has-network2/-/has-network2-0.0.3.tgz",
+      "integrity": "sha512-EvEZguA+LkyiS8G/Qks5I6imKnM2Z3NPN3eoQhviUQ7O6/d8nyZ7sDozBk6kTIA+Qj/S/V8ubRA1rqJcxc3qBQ=="
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
+    "node_modules/hoox": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz",
+      "integrity": "sha1-CKdNknKpzIOujmu+AwPw7nZDIJQ="
+    },
+    "node_modules/idb-kv-store": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.5.0.tgz",
+      "integrity": "sha512-snvtAQRforYUI+C2+45L2LBJy/0/uQUffxv8/uwiS98fSUoXHVrFPClgzWZWxT0drwkLHJRm9inZcYzTR42GLA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "promisize": "^1.1.2"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+    },
+    "node_modules/implausible": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/implausible/-/implausible-3.0.4.tgz",
+      "integrity": "sha512-hkbWNpe9BEQWgKQYpTKgbj1vG/O236nC6WEWv/W3umvbbcXc6H50pnz0H1FVh26grmhlFjXoL+M+2wCj4DxU5w==",
+      "dependencies": {
+        "ramda": "^0.27.0",
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6.13.4"
+      }
+    },
+    "node_modules/increment-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
+      "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/int53": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
+      "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w=="
+    },
+    "node_modules/ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.0.tgz",
+      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g=="
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-canonical-base64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-canonical-base64/-/is-canonical-base64-1.1.1.tgz",
+      "integrity": "sha512-o6t/DwgEapC0bsloqtegAQyZzQXaQ5+8fzsyf2KmLqupC2ifLFq/lMQiFCJeGpdSrK1o6GL+WW2lRU050lLlFg=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/is-my-ssb-valid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-my-ssb-valid/-/is-my-ssb-valid-1.1.0.tgz",
+      "integrity": "sha512-HAcl2v9tIkpjfVqaNgaqYWk2MW3WPZtj+XVpKUMgQRWEbLJdZ4orE5l9SJ5t+bQO1LB5rKeYGTlMfxSXEG1NTw==",
+      "dependencies": {
+        "is-my-json-valid": "^2.20.0",
+        "ssb-msg-content": "^1.0.1"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-typed-array/node_modules/es-abstract": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-valid-domain": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.17.tgz",
+      "integrity": "sha512-w0UWEXyrgPeWWwj9FVT14y4/dSIqWgjDkzxbsGDFpT+QRbyS9HTwwNvGus2IOR/03GzCpeChzSWK9Bo9WlStDA=="
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
+      "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
+    },
+    "node_modules/jsonpointer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/level": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+      "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+      "dependencies": {
+        "level-js": "^5.0.0",
+        "level-packager": "^5.1.0",
+        "leveldown": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/level-codec": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+      "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+    },
+    "node_modules/level-concat-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dependencies": {
+        "errno": "~0.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-iterator-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-js": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+      "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+      "dependencies": {
+        "abstract-leveldown": "~6.2.3",
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.3",
+        "ltgt": "^2.1.2"
+      }
+    },
+    "node_modules/level-packager": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+      "dependencies": {
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-post": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+      "dependencies": {
+        "ltgt": "^2.1.2"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dependencies": {
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leveldown": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
+      "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
+      "dependencies": {
+        "abstract-leveldown": "~6.2.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/leveldown/node_modules/node-gyp-build": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/levelup": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
+      "dependencies": {
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/libnested": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/libnested/-/libnested-1.5.0.tgz",
+      "integrity": "sha512-IR5ASkAU4NHTN1JFeP9bYvhARhaBg8VD8yUcmvNIvFWg6L3dsM2yK1A9EM6MpPvWYKH9SEiljB59ZUa5s2pYnA=="
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
+      "integrity": "sha512-/Qc+APf0jbeWSaeEruH0L1/tbbT+sbf884ZL0/zV/0JXaDPBzYkKbyb/wmxMHgAHzm3t6gqe7bOOXAVwfqVikQ=="
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.8.tgz",
+      "integrity": "sha512-PDhPWXBqd/SaqAFUBgH2Ux7b3VEEJgyD6BQB+VdNFJb9PbExGr/T/myc/MBoSvl8qLzfm0W0IVByOQS5L1MrCg==",
+      "dependencies": {
+        "libsodium": "0.7.8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
+    "node_modules/looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "node_modules/lorem-ipsum": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.3.tgz",
+      "integrity": "sha512-CX2r84DMWjW/DWiuzicTI9aRaJPAw2cvAGMJYZh/nx12OkTGqloj8y8FU0S8ZkKwOdqhfxEA6Ly8CW2P6Yxjwg==",
+      "dependencies": {
+        "commander": "^2.17.1"
+      },
+      "bin": {
+        "lorem-ipsum": "dist/bin/lorem-ipsum.bin.js"
+      },
+      "engines": {
+        "node": ">= 8.x",
+        "npm": ">= 5.x"
+      }
+    },
+    "node_modules/ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
+    "node_modules/map-filter-reduce": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.2.2.tgz",
+      "integrity": "sha512-p+NIGQbEBxlw/qWwG+NME98G/9kjOQI70hmaH8QEZtIWfTmfMYLKQW4PJChP4izPHNAxlOfv/qefP0+2ZXn84A==",
+      "dependencies": {
+        "binary-search": "^1.2.0",
+        "compare-at-paths": "^1.0.0",
+        "pull-sink-through": "0.0.0",
+        "pull-sort": "^1.0.1",
+        "pull-stream": "^3.4.3",
+        "typewiselite": "^1.0.0"
+      }
+    },
+    "node_modules/map-merge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz",
+      "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/monotonic-timestamp": {
+      "resolved": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86"
+    },
+    "node_modules/moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/multicb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz",
+      "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
+    },
+    "node_modules/multiserver": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.6.0.tgz",
+      "integrity": "sha512-MeANpx7//lJTwYKLYfsucdRvDafbyxaijUm9BhmF+QfLBMGRebNoKRYLhZItbHYAcsI0HBTtpBVHNw+bmRRnFQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "multicb": "^1.2.2",
+        "multiserver-scopes": "^1.0.0",
+        "pull-cat": "~1.1.5",
+        "pull-stream": "^3.6.1",
+        "pull-ws": "^3.3.0",
+        "secret-handshake": "^1.1.16",
+        "separator-escape": "0.0.0",
+        "socks": "^2.2.3",
+        "stream-to-pull-stream": "^1.7.2"
+      }
+    },
+    "node_modules/multiserver-address": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multiserver-address/-/multiserver-address-1.0.1.tgz",
+      "integrity": "sha512-IfZMAGs9onCLkYNSnNBri3JxuvhQYllMyh3W9ry86iEDcfW9uPVsHTHDsjDxQtL+dPq3byshmA+Y4LN2wLHwNw==",
+      "dependencies": {
+        "nearley": "^2.15.1"
+      }
+    },
+    "node_modules/multiserver-scopes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/multiserver-scopes/-/multiserver-scopes-1.0.0.tgz",
+      "integrity": "sha512-D3q4IujGRUIKETfR5s0kRtvXTjAMhyl7rtLEMXtvkg0lJPJyS5KYsAULFFy+dYv/+RC642aR1zo/RKNp6sdtQg==",
+      "dependencies": {
+        "non-private-ip": "^1.4.4"
+      }
+    },
+    "node_modules/mutexify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.3.1.tgz",
+      "integrity": "sha512-nU7mOEuaXiQIB/EgTIjYZJ7g8KqMm2D8l4qp+DqA4jxWOb/tnb1KEoqp+tlbdQIDIAiC1i7j7X/3yHDFXLxr9g=="
+    },
+    "node_modules/muxrpc": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.5.1.tgz",
+      "integrity": "sha512-QTHNncZlsEcBOOYqpCx/QeVLJYaov6Y1LCEDun0xu81zAJGKymiMd5TB/qzA+dm9o1K3axwdGOqPR3fzrDyGRw==",
+      "dependencies": {
+        "explain-error": "^1.0.1",
+        "packet-stream": "~2.0.0",
+        "packet-stream-codec": "^1.1.1",
+        "pull-goodbye": "0.0.2",
+        "pull-stream": "^3.6.10"
+      }
+    },
+    "node_modules/muxrpc-validation": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.2.tgz",
+      "integrity": "sha512-iWo/23xFnl+IGeX+LlfwoVKtyY4volPSodf3nwPScPgxjws4k2ZUozPG98OouMA0yn0JamqApjRw7eqLrzyV2A==",
+      "dependencies": {
+        "pull-stream": "^3.6.11",
+        "zerr": "^1.0.4"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
+    "node_modules/napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
+    },
+    "node_modules/nearley": {
+      "version": "2.19.7",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.7.tgz",
+      "integrity": "sha512-Y+KNwhBPcSJKeyQCFjn8B/MIe+DDlhaaDgjVldhy5xtFewIbiQgcbZV8k2gCVwkI1ZsKCnjIYZbR+0Fim5QYgg==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/non-private-ip": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
+      "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "bin": {
+        "non-private-ip": "bin.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+    },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obv": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
+      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
+    },
+    "node_modules/obz": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.2.tgz",
+      "integrity": "sha512-c+EtVwT2IpXz5we2mR40aPLJ1s0eNOsxYeaYbaHhmsY6kWKo3IRkpwpBU5ck0aHfqfKUUEiKabC6rzsrG/hSHw=="
+    },
+    "node_modules/on-change-network-strict": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-change-network-strict/-/on-change-network-strict-1.0.0.tgz",
+      "integrity": "sha512-ldHCpTJWgr5KUJy3/TVoSGNwBUA8BP9UFmd0iQqe4aGaXY4PJyzQPiVBIo8VBSlSoKyaJY3vcpW0hixZb6gPaA=="
+    },
+    "node_modules/on-wakeup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz",
+      "integrity": "sha1-ANedmH3efIEXvudLtJA/b22vpSs="
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/packet-stream": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.5.tgz",
+      "integrity": "sha512-+4S+qBUdqD57ka5MDd6nAYGBPril5eyLpbga2y0kPyYhrKvjb8CYTP9r40WLbSxgT/qEGmvgWOrvQe+FYtCI7w=="
+    },
+    "node_modules/packet-stream-codec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
+      "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
+      "dependencies": {
+        "pull-reader": "^1.2.4",
+        "pull-through": "^1.0.17"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "node_modules/plur": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "dev": true,
+      "dependencies": {
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/private-box": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.3.1.tgz",
+      "integrity": "sha512-abAuk3ZDyQvPLY6MygtwaDTUBIZ0C5wMMuX1jXa0svazV+keTwn7cPobRv4WYA9ctsDUztm/9CYu4y2TPL08xw==",
+      "dependencies": {
+        "chloride": "^2.2.9"
+      }
+    },
+    "node_modules/private-group-spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/private-group-spec/-/private-group-spec-1.0.0.tgz",
+      "integrity": "sha512-C4EJF39/13tKfUGbUzF/pgYTVNIOB6yWuWhz3IKTt4bmPeIG3EUAFsCsmk8E5x8Mzrg78fg2zpvstGoah11RHA=="
+    },
+    "node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "node_modules/promisify-4loc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promisify-4loc/-/promisify-4loc-1.0.0.tgz",
+      "integrity": "sha512-u/XtndUyqqDXAuhFEgFgkpjHG8IizREoj80j5dL4t41eE9yH0gzFPyOD21/VnikdPJtRziuqf6ryTu1HoTjyog==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/promisify-tuple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promisify-tuple/-/promisify-tuple-1.0.1.tgz",
+      "integrity": "sha512-st4Q1R6oAr8hzt1hj3uCYv87Pc5wtDkoq7ZqxWri2xR3x5Zvx7syH2DR4fgknVhMsZ6GV+kxEmhn2tVnwFMmJw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/promisize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/promisize/-/promisize-1.1.2.tgz",
+      "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE="
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "node_modules/pull-abortable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
+      "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
+    },
+    "node_modules/pull-box-stream": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
+      "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
+      "dependencies": {
+        "chloride": "^2.2.7",
+        "increment-buffer": "~1.0.0",
+        "pull-reader": "^1.2.5",
+        "pull-stream": "^3.2.3",
+        "pull-through": "^1.0.18",
+        "split-buffer": "~1.0.0"
+      }
+    },
+    "node_modules/pull-cat": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
+    },
+    "node_modules/pull-cont": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz",
+      "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg="
+    },
+    "node_modules/pull-cursor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
+      "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
+      "dependencies": {
+        "looper": "^4.0.0",
+        "ltgt": "^2.2.0",
+        "pull-stream": "^3.6.0"
+      }
+    },
+    "node_modules/pull-defer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
+    },
+    "node_modules/pull-flatmap": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pull-flatmap/-/pull-flatmap-0.0.1.tgz",
+      "integrity": "sha1-E9SURT6PbUeOe7+t5vj+AZf6a7c="
+    },
+    "node_modules/pull-goodbye": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
+      "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
+      "dependencies": {
+        "pull-stream": "~3.5.0"
+      }
+    },
+    "node_modules/pull-goodbye/node_modules/pull-stream": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz",
+      "integrity": "sha1-HuW292/Ts6SaWvtt7VwDIKyzz8c="
+    },
+    "node_modules/pull-handshake": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
+      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
+      "dependencies": {
+        "pull-cat": "^1.1.9",
+        "pull-pair": "~1.1.0",
+        "pull-pushable": "^2.0.0",
+        "pull-reader": "^1.2.3"
+      }
+    },
+    "node_modules/pull-inactivity": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.3.tgz",
+      "integrity": "sha512-swJ/jwkIN/O1bQCE3iY7Xy9r3gYuJ50MXaxZilw/HIduAy4tJu+vcz2/If0L+xNK7Ku/FfjtVbTpRTe7sf3hmA==",
+      "dependencies": {
+        "pull-abortable": "~4.0.0",
+        "pull-stream": "^3.4.5"
+      }
+    },
+    "node_modules/pull-inactivity/node_modules/pull-abortable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz",
+      "integrity": "sha1-cBephMO4NN53usOMELd28i38GEM="
+    },
+    "node_modules/pull-level": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+      "dependencies": {
+        "level-post": "^1.0.7",
+        "pull-cat": "^1.1.9",
+        "pull-live": "^1.0.1",
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.0",
+        "pull-window": "^2.1.4",
+        "stream-to-pull-stream": "^1.7.1"
+      }
+    },
+    "node_modules/pull-live": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+      "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+      "dependencies": {
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.0"
+      }
+    },
+    "node_modules/pull-looper": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
+      "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
+      "dependencies": {
+        "looper": "^4.0.0"
+      }
+    },
+    "node_modules/pull-notify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
+      "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
+      "dependencies": {
+        "pull-pushable": "^2.0.0"
+      }
+    },
+    "node_modules/pull-pair": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
+      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
+    },
+    "node_modules/pull-paramap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
+      "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
+      "dependencies": {
+        "looper": "^4.0.0"
+      }
+    },
+    "node_modules/pull-pause": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/pull-pause/-/pull-pause-0.0.2.tgz",
+      "integrity": "sha1-GdRb6PqmFfpVbxSpb9czRiw3+6M="
+    },
+    "node_modules/pull-ping": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.3.tgz",
+      "integrity": "sha512-nbY4yHnMesJBrvkbhMim4VXUC9k1VCkgrkQu49pf8mxFbmb/U2KQrsuePvSmLjRL+VgkBVRSUXUoOY7DtSvhKw==",
+      "dependencies": {
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.5",
+        "statistics": "^3.3.0"
+      }
+    },
+    "node_modules/pull-pushable": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
+    },
+    "node_modules/pull-rate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
+      "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
+      "dependencies": {
+        "pull-stream": "^3.6.0"
+      }
+    },
+    "node_modules/pull-reader": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
+      "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
+    },
+    "node_modules/pull-sink-through": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
+      "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
+    },
+    "node_modules/pull-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.2.tgz",
+      "integrity": "sha512-jGcAHMP+0Le+bEIhSODlbNNd3jW+S6XrXOlhVzfcKU5HQZjP92OzQSgHHSlwvWRsiTWi+UGgbFpL/5gGgmFoVQ==",
+      "dependencies": {
+        "pull-defer": "^0.2.3",
+        "pull-stream": "^3.6.9"
+      }
+    },
+    "node_modules/pull-stream": {
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
+    },
+    "node_modules/pull-through": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
+      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
+      "dependencies": {
+        "looper": "~3.0.0"
+      }
+    },
+    "node_modules/pull-through/node_modules/looper": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+    },
+    "node_modules/pull-window": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+      "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+      "dependencies": {
+        "looper": "^2.0.0"
+      }
+    },
+    "node_modules/pull-window/node_modules/looper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+      "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
+    },
+    "node_modules/pull-write": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
+      "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
+      "dependencies": {
+        "looper": "^4.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-stream": "^3.4.5"
+      }
+    },
+    "node_modules/pull-ws": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.2.tgz",
+      "integrity": "sha512-Bn4bcJsSzJGOQl4RBulDhG1FkcbDHSCXteI8Jg5k4X6X5TxVzZzKilWJ1WV2v4OnRXl2eYbtHFGsPl8Cr1xJzw==",
+      "dependencies": {
+        "relative-url": "^1.0.2",
+        "safe-buffer": "^5.1.1",
+        "ws": "^1.1.0"
+      }
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+    },
+    "node_modules/ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/re-emitter": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
+      "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc=",
+      "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/regexp.prototype.flags/node_modules/es-abstract": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/relative-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
+      "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.0.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rwlock": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
+      "integrity": "sha1-iI1qd6M1HMGiCSBO8u4XIgk4Ns8="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "node_modules/scuttle-testbot": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/scuttle-testbot/-/scuttle-testbot-1.5.0.tgz",
+      "integrity": "sha512-QCJLqhC1BH1gQWNOcaMki1ny/qRyld36NEY/0ddAGdF8/D7p6ACqer3iVou9Bc9YRgf23yxs8bZaCSzglmNhjA==",
+      "dependencies": {
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.14",
+        "rimraf": "^3.0.0",
+        "secret-stack": "^6.3.1",
+        "ssb-conn": "^0.19.1",
+        "ssb-db": "^20.3.0",
+        "ssb-keys": "^8.0.0"
+      }
+    },
+    "node_modules/secret-handshake": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.20.tgz",
+      "integrity": "sha512-sDtmZDpibGH2ixj3FOmsC3Z/b08eaB2/KAvy2oSp4qvcGdhatBSfb1RdVpwjQl5c3J83WbBo1HSZ7DBtMu43lA==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "explain-error": "^1.0.4",
+        "pull-box-stream": "^1.0.13",
+        "pull-handshake": "^1.1.1",
+        "pull-stream": "^3.4.5"
+      }
+    },
+    "node_modules/secret-stack": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.3.1.tgz",
+      "integrity": "sha512-SyYRGgjxq8lbQyqdIbaNfteZ77B3Bd2TH+k5WpI6gHjTCOKZZmD8aiat+bUfhjsiqf0LMQauRH3KD6vIMdDPLg==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "hoox": "0.0.1",
+        "ip": "^1.1.5",
+        "map-merge": "^1.1.0",
+        "multiserver": "^3.1.0",
+        "muxrpc": "^6.4.8",
+        "non-private-ip": "^1.4.3",
+        "pull-inactivity": "~2.1.1",
+        "pull-rate": "^1.0.2",
+        "pull-stream": "^3.4.5",
+        "stream-to-pull-stream": "^1.6.1",
+        "to-camel-case": "^1.0.0"
+      }
+    },
+    "node_modules/secret-stack-decorators": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/secret-stack-decorators/-/secret-stack-decorators-1.1.0.tgz",
+      "integrity": "sha512-wYl0Mcul/fuEbZwn9tN62c+W4LP2RPus/ilt3wdBNQqfBFSMlDXTLaIsrA4SEElb7JEBH4xzdQbOCnTvYHeWCA=="
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/separator-escape": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
+      "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+      "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
+      "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
+      "dependencies": {
+        "es-abstract": "^1.18.0-next.0",
+        "object-inspect": "^1.8.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.5.0.tgz",
+      "integrity": "sha512-00OqQHp5SCbwm9ecOMJj9aQtMSjwi1uVuGQoxnpKCS50VKZcOZ8z11CTKypmR8sEy7nZimy/qXY7rYJYbRlXmA==",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sodium-browserify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.3.0.tgz",
+      "integrity": "sha512-1KRS6Oew3X13AIZhbmGF0YBdt2pQdafJMfv83OZHWbzxG92YBBnN8HYx/VKmYB4xCe90eidNaDJWBEFw/o3ahw==",
+      "dependencies": {
+        "libsodium-wrappers": "^0.7.4",
+        "sha.js": "2.4.5",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "tweetnacl": "^0.14.1"
+      }
+    },
+    "node_modules/sodium-browserify-tweetnacl": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.6.tgz",
+      "integrity": "sha512-ZnEI26hdluilpYY28Xc4rc1ALfmEp2TWihkJX6Mdtw0z9RfHfpZJU7P8DoKbN1HcBdU9aJmguFZs7igE8nLJPg==",
+      "dependencies": {
+        "chloride-test": "^1.1.0",
+        "ed2curve": "^0.1.4",
+        "sha.js": "^2.4.8",
+        "tweetnacl": "^1.0.1",
+        "tweetnacl-auth": "^0.3.0"
+      }
+    },
+    "node_modules/sodium-browserify-tweetnacl/node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/sodium-browserify-tweetnacl/node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "node_modules/sodium-chloride": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.2.tgz",
+      "integrity": "sha512-8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g=="
+    },
+    "node_modules/sodium-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
+      "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "node-gyp-build": "^4.2.0"
+      }
+    },
+    "node_modules/split": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
+      "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/ssb-backlinks": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-2.1.1.tgz",
+      "integrity": "sha512-iv/B5EyjvNiKOeT3RkTuBRyU14GJ1sf5wnr07JOWeVI3OyNzedZ8z229yzZSaGHTYpbiSOcs9Z2CR8CkLQupQQ==",
+      "dependencies": {
+        "base64-url": "^2.3.3",
+        "flumeview-links": "^2.1.0",
+        "pull-stream": "^3.6.14",
+        "ssb-ref": "^2.14.0"
+      }
+    },
+    "node_modules/ssb-caps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-caps/-/ssb-caps-1.1.0.tgz",
+      "integrity": "sha512-qe3qpvchJ+gnH8M/ge4rpL+7eRbSmsEAzNwHkDdrW06OBcziQ6/KuAdmcR6joxCbNeoAXAZF+inkefgE16okXA=="
+    },
+    "node_modules/ssb-config": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.4.5.tgz",
+      "integrity": "sha512-DyCrGIsl01GkdHreAkkaDUorV7SAgRSqKn/htg4ZwbvH6g0NAdOi84x/8ehzDuojPev78hbkWjZXgIqi+/Jo0g==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ip": "^1.1.5",
+        "lodash.get": "^4.4.2",
+        "os-homedir": "^1.0.1",
+        "rc": "^1.1.6",
+        "ssb-caps": "^1.0.1",
+        "ssb-keys": "^7.1.4"
+      }
+    },
+    "node_modules/ssb-config/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ssb-config/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/ssb-conn": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.19.1.tgz",
+      "integrity": "sha512-7HEiZPZyeIurrZsL1kxYgM164eNU+PRbqfhMzGNwQOrU5Ku+tciZhrZsbYtgNJHHIaoQQZfX79IaQQsD1ZrW5A==",
+      "dependencies": {
+        "debug": "~4.2.0",
+        "has-network2": ">=0.0.3",
+        "ip": "^1.1.5",
+        "on-change-network-strict": "1.0.0",
+        "on-wakeup": "^1.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-pause": "~0.0.2",
+        "pull-ping": "^2.0.3",
+        "pull-stream": "^3.6.14",
+        "secret-stack-decorators": "1.1.0",
+        "ssb-conn-db": "~0.3.3",
+        "ssb-conn-hub": "~0.2.7",
+        "ssb-conn-query": "~0.4.6",
+        "ssb-conn-staging": "~0.1.0",
+        "ssb-ref": "^2.14.2",
+        "ssb-typescript": "^2.1.0",
+        "statistics": "^3.3.0",
+        "zii": "~1.1.0"
+      },
+      "peerDependencies": {
+        "secret-stack": ">=6.2.0"
+      }
+    },
+    "node_modules/ssb-conn-db": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.3.3.tgz",
+      "integrity": "sha512-N2C/PweOlzEnrcfhGusnFhrZusfGyEMqip2WpQR/dgLAwHHQK8Wxn9KkC0457AHYlIO3UDH4Q1Mewsz8RLweMw==",
+      "dependencies": {
+        "atomic-file": "^2.1.1",
+        "debug": "~4.1.1",
+        "multiserver-address": "~1.0.1",
+        "pull-notify": "~0.1.1",
+        "ssb-ref": "~2.13.9"
+      }
+    },
+    "node_modules/ssb-conn-db/node_modules/debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/ssb-conn-db/node_modules/ssb-ref": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+      "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+      "dependencies": {
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "node_modules/ssb-conn-hub": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.2.7.tgz",
+      "integrity": "sha512-fvX7HK44V65C8uMQhTK9B4SHZE7K5P0AU/cHVuDciKPNagEFV0QHKk//JnrrMKHKKvz1msKUxhA0S0iH0S4gqQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "ip": "^1.1.5",
+        "multiserver": "^3.4.0",
+        "multiserver-address": "~1.0.1",
+        "promisify-tuple": "^1.0.0",
+        "pull-cat": "~1.1.11",
+        "pull-notify": "~0.1.1",
+        "pull-stream": "~3.6.9",
+        "ssb-ref": "~2.13.9"
+      }
+    },
+    "node_modules/ssb-conn-hub/node_modules/ssb-ref": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+      "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+      "dependencies": {
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "node_modules/ssb-conn-query": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.6.tgz",
+      "integrity": "sha512-qwa0xYK4r3DwbJQQ/K5umw4VAt3aGTkRbFN0E43Mb33+M94jnXMhDIxZWrPoX1vVQSRZLlCb+laXQiGlxW32AQ==",
+      "dependencies": {
+        "ssb-conn-db": "~0.3.3",
+        "ssb-conn-hub": "~0.2.7",
+        "ssb-conn-staging": "~0.1.0"
+      }
+    },
+    "node_modules/ssb-conn-staging": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-0.1.0.tgz",
+      "integrity": "sha512-bFtArSUiF3QrJ9LJ1auonC40pxJd58eBzozBiWsburwbZLUuxqrnW/kCaoyu+PYwTvc0FvMzZR/g4yL2wcE4Yw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "multiserver-address": "~1.0.1",
+        "pull-cat": "~1.1.11",
+        "pull-notify": "~0.1.1",
+        "pull-stream": "^3.6.9"
+      }
+    },
+    "node_modules/ssb-crut": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ssb-crut/-/ssb-crut-2.1.2.tgz",
+      "integrity": "sha512-E8dO40XBVN+WmbTlsLHAmvcUjBNyWMOx+4qTU+/YTFbM/ZPLy/M8hoJ0IzRnOl1c3pglvyKkYVJXwWHBfYXo0Q==",
+      "dependencies": {
+        "@tangle/reduce": "^3.1.0",
+        "@tangle/strategy": "^2.0.1",
+        "is-my-ssb-valid": "^1.1.0",
+        "lodash.merge": "^4.6.2",
+        "pull-stream": "^3.6.14",
+        "ssb-schema-definitions": "^3.2.1"
+      }
+    },
+    "node_modules/ssb-db": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-20.3.0.tgz",
+      "integrity": "sha512-JOXCrS6k3+/kuOcFmZwc9vxPN55Czb7McFs5KEYA+/phykPwQ6e3hwjMT5YrVzSirCf8ptPS/mpOsCDog5Z2dg==",
+      "dependencies": {
+        "flumedb": "^2.1.8",
+        "flumelog-offset": "^3.4.2",
+        "flumeview-level": "^4.0.4",
+        "flumeview-reduce": "^1.3.17",
+        "hashlru": "^2.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "ltgt": "^2.2.0",
+        "mkdirp": "^1.0.4",
+        "monotonic-timestamp": "~0.0.8",
+        "muxrpc-validation": "^3.0.0",
+        "obv": "0.0.1",
+        "pull-cat": "^1.1.11",
+        "pull-cont": "^0.1.1",
+        "pull-notify": "^0.1.1",
+        "pull-stream": "^3.4.0",
+        "rimraf": "^3.0.0",
+        "ssb-keys": "^7.1.3",
+        "ssb-msgs": "^5.0.0",
+        "ssb-ref": "^2.14.0",
+        "ssb-validate": "^4.0.0",
+        "zerr": "^1.0.0"
+      }
+    },
+    "node_modules/ssb-db/node_modules/monotonic-timestamp": {
+      "resolved": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86"
+    },
+    "node_modules/ssb-db/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/ssb-db/node_modules/ssb-keys/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ssb-keys": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.0.tgz",
+      "integrity": "sha512-PJnRSRtYjwEDS/I+UTCyC1JocGCOlK43ghp54Y5oQMJvv8tczuoz4oSUFZjBN6+ubLMqGkPLtgo4+58g1gXg9g==",
+      "dependencies": {
+        "chloride": "~2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "~0.3.0"
+      },
+      "engines": {
+        "node": ">=5.10.0"
+      }
+    },
+    "node_modules/ssb-keys/node_modules/chloride": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.14.tgz",
+      "integrity": "sha512-Jp3kpDIO4MlcJCFi4jER9P7k3sAVvIwbe4QJtM9Nkp43e/GQ/98HU1wJS6NdU6cbzfGrKWmMdRB+VNRrCynzfw==",
+      "dependencies": {
+        "is-electron": "^2.2.0",
+        "sodium-browserify": "^1.2.7",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "sodium-chloride": "^1.1.2"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^2.1.6"
+      }
+    },
+    "node_modules/ssb-keys/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ssb-keys/node_modules/sodium-native": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.9.tgz",
+      "integrity": "sha512-mbkiyA2clyfwAyOFIzMvsV6ny2KrKEIhFVASJxWfsmgfUEymgLIS2MLHHcGIQMkrcKhPErRaMR5Dzv0EEn+BWg==",
+      "optional": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "nan": "^2.14.0",
+        "node-gyp-build": "^4.1.0"
+      }
+    },
+    "node_modules/ssb-logging": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-logging/-/ssb-logging-1.0.0.tgz",
+      "integrity": "sha512-6apTG47+VgLAD3MYkpRTbO27DMDh0YLJIvWfcJUEo5FdrjnLsqDl1kkzQ4B5MbH08z5Vklx5907t4by9rhlROQ==",
+      "dependencies": {
+        "bash-color": "0.0.4"
+      }
+    },
+    "node_modules/ssb-master": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ssb-master/-/ssb-master-1.0.3.tgz",
+      "integrity": "sha512-N1Cxm9WscGD9VEZrWbF2amyQai2U2g9gtq57W5zTqbhlQTLUUvl84U9A6fg6GPkECnUXadulnTw+mMYVkLLHjQ=="
+    },
+    "node_modules/ssb-msg-content": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-msg-content/-/ssb-msg-content-1.0.1.tgz",
+      "integrity": "sha512-M6W0Ef+jif829USmGvh6XeS4lYb/F2lgFhfEoCE/md7ESILNOGidp8frJE2uVOzSr2wVRA265tPrnVb7rYHkug=="
+    },
+    "node_modules/ssb-msgs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
+      "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
+      "dependencies": {
+        "ssb-ref": "^2.0.0"
+      }
+    },
+    "node_modules/ssb-private1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-private1/-/ssb-private1-1.0.1.tgz",
+      "integrity": "sha512-x69YHNhjxCrknkK7XbEJyk2P0P3p52t6NF74I8ObHIrBdWnyRrO6iUH8K5b8CkaHawM4giXdZG5cyrOPzPN/Fg==",
+      "dependencies": {
+        "ssb-keys": "^7.2.2",
+        "ssb-ref": "^2.13.9"
+      }
+    },
+    "node_modules/ssb-private1/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ssb-private1/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/ssb-query": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.5.tgz",
+      "integrity": "sha512-/QX6+DJkghqq1ZTbgYpOvaI+gx2O7ee1TRUM9yiOlVjh1XAQBevcBj0zO+W3TsNllX86urqBrySd/AEfFfUpIw==",
+      "dependencies": {
+        "explain-error": "^1.0.1",
+        "flumeview-query": "^8.0.0",
+        "pull-stream": "^3.6.2"
+      }
+    },
+    "node_modules/ssb-ref": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.14.2.tgz",
+      "integrity": "sha512-pPkwNX/Rrr0bV/8d8dC/f+T/LcKA9ZF1SGHrUuVpoqo8iE3gLMu0Zz5TRoUReXKW6+ehNzUzIjcpYTw+wWeZkA==",
+      "dependencies": {
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "node_modules/ssb-schema-definitions": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ssb-schema-definitions/-/ssb-schema-definitions-3.2.1.tgz",
+      "integrity": "sha512-+KBljo89bBi4gv3dnoiop4PexKLlySzq5bDcHvQ5aE4zXB8V33hocHuoJbihPr/jxry4kiqqo31TETwjV8YerQ==",
+      "dependencies": {
+        "lodash.clone": "^4.5.0",
+        "ssb-ref": "^2.14.0"
+      }
+    },
+    "node_modules/ssb-tribes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-tribes/-/ssb-tribes-2.0.1.tgz",
+      "integrity": "sha512-qkzzlJ07pPXaAxh6XtH/eDTYbDV+daG7oPHGZOkvduS778v8b7nZxKnQgji+ZtnCEr3tbWVQGMsBC6SHc7JPZw==",
+      "dependencies": {
+        "@tangle/linear-append": "^1.0.0",
+        "@tangle/overwrite": "^2.0.1",
+        "@tangle/reduce": "^3.1.0",
+        "@tangle/strategy": "^2.0.1",
+        "charwise": "^3.0.1",
+        "envelope-js": "^1.0.0",
+        "envelope-spec": "^1.0.0",
+        "futoin-hkdf": "^1.3.2",
+        "is-my-ssb-valid": "^1.1.0",
+        "level": "^6.0.1",
+        "lodash.set": "^4.3.2",
+        "mkdirp": "^1.0.4",
+        "obz": "^1.0.3",
+        "private-group-spec": "^1.0.0",
+        "pull-level": "^2.0.4",
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.14",
+        "sodium-native": "^3.2.0",
+        "ssb-crut": "^2.1.2",
+        "ssb-keys": "^8.0.2",
+        "ssb-ref": "^2.14.3",
+        "ssb-schema-definitions": "^3.1.0"
+      }
+    },
+    "node_modules/ssb-tribes/node_modules/obz": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.3.tgz",
+      "integrity": "sha512-rH3U4eLHsV+OgkOS29ULiC9JLspwMCyCIH/+BglLPXDxQs13IK8AGD+nVmkGXqGN5JefZu85YhfIi05CsOKWPw=="
+    },
+    "node_modules/ssb-tribes/node_modules/ssb-keys": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.2.tgz",
+      "integrity": "sha512-u2U9t5YLbFShKQzr+ayMx9cYNvUJzDeOScodMwfP5zM3+/1AStvc5W91knZGllGwsmGjNC57KW+whRun+H/dBQ==",
+      "dependencies": {
+        "chloride": "~2.4.1",
+        "mkdirp": "~0.5.0",
+        "private-box": "~0.3.0"
+      },
+      "engines": {
+        "node": ">=5.10.0"
+      }
+    },
+    "node_modules/ssb-tribes/node_modules/ssb-keys/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ssb-tribes/node_modules/ssb-ref": {
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.14.3.tgz",
+      "integrity": "sha512-XhzVmezsUJLlKxTfWlicxhiPRTEYHfJLskYQNRSnw4USqgo9LVx53+MJAhdZOYpZTW2jINR0TeetWs9M27gcbA==",
+      "dependencies": {
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "node_modules/ssb-typescript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-typescript/-/ssb-typescript-2.1.0.tgz",
+      "integrity": "sha512-UlnCQO4d24+bCoo7g6vXLipoCOnouPR6+ch+PT+BqvxwDJLJDdNDDWBH3g8GNJa6No2JoojNoubzpAStDBHgmg=="
+    },
+    "node_modules/ssb-validate": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-4.1.3.tgz",
+      "integrity": "sha512-g7tOs4nCwHk+G/FZ1N2RmaCkaTNS9hoh/BBP12EH8Jf1PWlkOJtTCak78FHjSTAGFCq/i8Y1ZFQXPNKSK7p3wg==",
+      "dependencies": {
+        "is-canonical-base64": "^1.1.1",
+        "monotonic-timestamp": "0.0.9",
+        "ssb-keys": "^7.0.7",
+        "ssb-ref": "^2.6.2"
+      }
+    },
+    "node_modules/ssb-validate/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ssb-validate/node_modules/monotonic-timestamp": {
+      "resolved": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86"
+    },
+    "node_modules/ssb-validate/node_modules/ssb-keys": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+      "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+      "dependencies": {
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
+      }
+    },
+    "node_modules/statistics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz",
+      "integrity": "sha1-7HtHUP8DqySmTdmzV6eDFr6teKo="
+    },
+    "node_modules/stream-to-pull-stream": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+      "dependencies": {
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
+      }
+    },
+    "node_modules/stream-to-pull-stream/node_modules/looper": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz",
+      "integrity": "sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/tap-bail": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tap-bail/-/tap-bail-1.0.0.tgz",
+      "integrity": "sha1-xajMcRkfA3k4zVZ/l72jypcAGZo=",
+      "dev": true,
+      "dependencies": {
+        "tap-parser": "^5.3.3"
+      },
+      "bin": {
+        "tap-bail": "bin/tap-bail.js"
+      }
+    },
+    "node_modules/tap-out": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-2.1.0.tgz",
+      "integrity": "sha512-LJE+TBoVbOWhwdz4+FQk40nmbIuxJLqaGvj3WauQw3NYYU5TdjoV3C0x/yq37YAvVyi+oeBXmWnxWSjJ7IEyUw==",
+      "dev": true,
+      "dependencies": {
+        "re-emitter": "1.1.3",
+        "readable-stream": "2.2.9",
+        "split": "1.0.0",
+        "trim": "0.0.1"
+      },
+      "bin": {
+        "tap-out": "bin/cmd.js"
+      }
+    },
+    "node_modules/tap-out/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/tap-out/node_modules/readable-stream": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+      "dev": true,
+      "dependencies": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/tap-out/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/tap-out/node_modules/string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tap-parser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+      "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+      "dev": true,
+      "dependencies": {
+        "events-to-array": "^1.0.1",
+        "js-yaml": "^3.2.7"
+      },
+      "bin": {
+        "tap-parser": "bin/cmd.js"
+      },
+      "optionalDependencies": {
+        "readable-stream": "^2"
+      }
+    },
+    "node_modules/tap-parser/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/tap-parser/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/tap-parser/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/tap-parser/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/tap-parser/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tap-spec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-5.0.0.tgz",
+      "integrity": "sha512-zMDVJiE5I6Y4XGjlueGXJIX2YIkbDN44broZlnypT38Hj/czfOXrszHNNJBF/DXR8n+x6gbfSx68x04kIEHdrw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "duplexer": "^0.1.1",
+        "figures": "^1.4.0",
+        "lodash": "^4.17.10",
+        "pretty-ms": "^2.1.0",
+        "repeat-string": "^1.5.2",
+        "tap-out": "^2.1.0",
+        "through2": "^2.0.0"
+      },
+      "bin": {
+        "tap-spec": "bin/cmd.js",
+        "tspec": "bin/cmd.js"
+      }
+    },
+    "node_modules/tape": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.0.1.tgz",
+      "integrity": "sha512-wVsOl2shKPcjdJdc8a+PwacvrOdJZJ57cLUXlxW4TQ2R6aihXwG0m0bKm4mA4wjtQNTaLMCrYNEb4f9fjHKUYQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "^2.0.3",
+        "defined": "^1.0.0",
+        "dotignore": "^0.1.2",
+        "for-each": "^0.3.3",
+        "function-bind": "^1.1.1",
+        "glob": "^7.1.6",
+        "has": "^1.0.3",
+        "inherits": "^2.0.4",
+        "is-regex": "^1.0.5",
+        "minimist": "^1.2.5",
+        "object-inspect": "^1.7.0",
+        "object-is": "^1.1.2",
+        "object.assign": "^4.1.0",
+        "resolve": "^1.17.0",
+        "resumer": "^0.0.0",
+        "string.prototype.trim": "^1.2.1",
+        "through": "^2.3.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/tape/node_modules/deep-equal": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.4.tgz",
+      "integrity": "sha512-BUfaXrVoCfgkOQY/b09QdO9L3XNoF2XH0A3aY9IQwQL/ZjLOe8FQgCNVl1wiolhsFo8kFdO9zdPViCPbmaJA5w==",
+      "dev": true,
+      "dependencies": {
+        "es-abstract": "^1.18.0-next.1",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/to-camel-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+      "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "node_modules/to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+    },
+    "node_modules/to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+      "dependencies": {
+        "to-no-case": "^1.0.0"
+      }
+    },
+    "node_modules/trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "node_modules/tweetnacl-auth": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
+      "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
+      "dependencies": {
+        "tweetnacl": "0.x.x"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typewiselite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+      "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
+    },
+    "node_modules/uint48be": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-2.0.1.tgz",
+      "integrity": "sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg=="
+    },
+    "node_modules/ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
+      "integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
+      "dependencies": {
+        "is-bigint": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/which-typed-array/node_modules/es-abstract": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "dependencies": {
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.0.tgz",
+      "integrity": "sha512-upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.2",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+      "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/zerr": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/zerr/-/zerr-1.0.4.tgz",
+      "integrity": "sha1-YoFN15nv+DYfKiKPQfcFxeGd5Mk="
+    },
+    "node_modules/zii": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/zii/-/zii-1.1.1.tgz",
+      "integrity": "sha512-nOC9WLdEOvBFoxbuc/iHZ0bsudW/nUBOLQK3hQRfp/TD3/pyQoWpBKJlmd11GgHLQEVRp2KemIeHQcBHQJx/DA=="
+    }
+  },
   "dependencies": {
+    "@tangle/graph": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@tangle/graph/-/graph-2.1.0.tgz",
+      "integrity": "sha512-Jx4W39lLjAAd13Rh7+m8Yi742NVp1kbbz6W4sv/jPStb/K/+0nj4Rafe3jW9EkazInrTXtQAuY7VEAeVaYmEew==",
+      "requires": {
+        "lodash.clone": "^4.5.0",
+        "lodash.set": "^4.3.2"
+      }
+    },
+    "@tangle/linear-append": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tangle/linear-append/-/linear-append-1.0.0.tgz",
+      "integrity": "sha512-fZh+o7JfLTVt+VefmSk4ROjlJtoWYVedM2+29Xgnigli5tztmh+2wYqcW6fB7ivckHW3OtNWgKDHJzDiOqaybA==",
+      "requires": {
+        "is-my-json-valid": "^2.20.5"
+      }
+    },
+    "@tangle/overwrite": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tangle/overwrite/-/overwrite-2.0.1.tgz",
+      "integrity": "sha512-PyV+LGXKVJrN3MHU6suRJNmDZxUJKOw8fU3w0lMykmUOjHKooFw0fkXYqLLhR3u6scfZP1ECi+TXQtIy6b4kOQ==",
+      "requires": {
+        "is-my-json-valid": "^2.20.5",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
+    "@tangle/reduce": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tangle/reduce/-/reduce-3.1.0.tgz",
+      "integrity": "sha512-FonAaam87HgJ1d9qXDqnbyRdRzIObM7UmhsdpD+2RTuvdl6Eu9UyNkkU9jqAX5r2elgfYAUgKYQ8KJ9XDw9xYg==",
+      "requires": {
+        "@tangle/graph": "^2.1.0"
+      }
+    },
+    "@tangle/strategy": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tangle/strategy/-/strategy-2.0.1.tgz",
+      "integrity": "sha512-zQcdCXLbNAWH28VStWNR7bLV/gakjBgdi0KXlc/kRH8JB2+HXfz2jCVVsEzb5H6pGhZuJ7GMjI7wJgnMbvldxw==",
+      "requires": {
+        "is-my-json-valid": "^2.20.5",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
     "@types/node": {
       "version": "14.14.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
@@ -63,11 +3651,19 @@
       "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.2.tgz",
       "integrity": "sha1-1zm0UDiIJF1Hkz1HVisRSf+d+Lc="
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "array-filter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-      "dev": true
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
     "async-single": {
       "version": "1.0.5",
@@ -88,7 +3684,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
       "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-      "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
       }
@@ -103,10 +3698,20 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
+    "base64-url": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.3.tgz",
+      "integrity": "sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q=="
+    },
     "bash-color": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
       "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
+    },
+    "binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -126,17 +3731,75 @@
         "ieee754": "^1.1.13"
       }
     },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "charwise": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
       "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
     },
     "chloride": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.3.0.tgz",
-      "integrity": "sha512-9jcavUx9ZNW9hxkG24rS9QddHpOqLAZqcb5SRbABRa8NKcplBKKcZfNM5LMa3DQ/VfXBQzcLDjgSo3uHA1ibZg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.1.tgz",
+      "integrity": "sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==",
       "requires": {
-        "is-electron": "^2.2.0",
         "sodium-browserify": "^1.2.7",
         "sodium-browserify-tweetnacl": "^0.2.5",
         "sodium-chloride": "^1.1.2",
@@ -178,6 +3841,61 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "compare-at-paths": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/compare-at-paths/-/compare-at-paths-1.0.0.tgz",
+      "integrity": "sha512-Ke1ejo/RZ+Hzku4gcW34uPMOR4Cpq87MAotELgV9mwiAzDN726cu+eWo0zWg1vRIfyf6yK5bW9uIW+c/SksQ5w==",
+      "requires": {
+        "libnested": "^1.3.2",
+        "tape": "^4.9.1",
+        "typewiselite": "^1.0.0"
+      },
+      "dependencies": {
+        "is-regex": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "object-inspect": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "tape": {
+          "version": "4.13.3",
+          "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
+          "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
+          "requires": {
+            "deep-equal": "~1.1.1",
+            "defined": "~1.0.0",
+            "dotignore": "~0.1.2",
+            "for-each": "~0.3.3",
+            "function-bind": "~1.1.1",
+            "glob": "~7.1.6",
+            "has": "~1.0.3",
+            "inherits": "~2.0.4",
+            "is-regex": "~1.0.5",
+            "minimist": "~1.2.5",
+            "object-inspect": "~1.7.0",
+            "resolve": "~1.17.0",
+            "resumer": "~0.0.0",
+            "string.prototype.trim": "~1.2.1",
+            "through": "~2.3.8"
+          }
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -243,6 +3961,12 @@
       "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
       "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -289,8 +4013,7 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "discontinuous-range": {
       "version": "1.0.0",
@@ -301,10 +4024,15 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
       "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
-      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "ed2curve": {
       "version": "0.1.4",
@@ -340,6 +4068,22 @@
         }
       }
     },
+    "envelope-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/envelope-js/-/envelope-js-1.0.0.tgz",
+      "integrity": "sha512-Z0zHgYNMZIOqR6CehiPowBwzq9uB9ikcp2WexCiOGcBMOsfsB0dQR65VnVkqZnTFUmi9fGC1syptGEM1TULz7g==",
+      "requires": {
+        "buffer-xor": "^2.0.2",
+        "envelope-spec": "^1.0.0",
+        "futoin-hkdf": "^1.3.2",
+        "sodium-native": "^3.2.0"
+      }
+    },
+    "envelope-spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/envelope-spec/-/envelope-spec-1.0.0.tgz",
+      "integrity": "sha512-NJ/neUZbvGgrq/cVmMZvNR58aypn3017/WIVIeOJCtMdREdkKa3G6tTMo40RqONNI3QyPtDocpBdtkbisHim2Q=="
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -368,39 +4112,18 @@
       }
     },
     "es-get-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
-      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
-      "dev": true,
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
       "requires": {
-        "es-abstract": "^1.17.4",
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
         "has-symbols": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
         "is-string": "^1.0.5",
         "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "es-to-primitive": {
@@ -418,10 +4141,38 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
+    },
     "explain-error": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
       "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
     },
     "flumecodec": {
       "version": "0.0.1",
@@ -479,6 +4230,56 @@
         "pull-write": "^1.1.1"
       }
     },
+    "flumeview-links": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/flumeview-links/-/flumeview-links-2.1.0.tgz",
+      "integrity": "sha512-VzqbNJ9qYE9eopCrhWXlPSoIoW4xanMy6YFyVSaYAwQIPoIZ+F1s1D3vmzOLXGhPesgHiXAlxmFSzXM5C9DKbQ==",
+      "requires": {
+        "deep-equal": "^2.0.3",
+        "flumeview-level": "^4.0.3",
+        "map-filter-reduce": "^3.2.2",
+        "pull-flatmap": "0.0.1",
+        "pull-stream": "^3.6.14"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
+          "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "es-get-iterator": "^1.1.1",
+            "get-intrinsic": "^1.0.1",
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.2",
+            "is-regex": "^1.1.1",
+            "isarray": "^2.0.5",
+            "object-is": "^1.1.4",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "regexp.prototype.flags": "^1.3.0",
+            "side-channel": "^1.0.3",
+            "which-boxed-primitive": "^1.0.1",
+            "which-collection": "^1.0.1",
+            "which-typed-array": "^1.1.2"
+          }
+        }
+      }
+    },
+    "flumeview-query": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-8.0.0.tgz",
+      "integrity": "sha512-uPTT5I26ePMc6Xhjebu1aiaHAd7P3EqyE9SZB6B9ZIvXtMXhFYNk7iO1yzh1ZXp3aYzdYmrI9k8mSz9urZ9gNQ==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "flumeview-level": "^4.0.3",
+        "map-filter-reduce": "^3.2.0",
+        "pull-flatmap": "0.0.1",
+        "pull-paramap": "^1.1.3",
+        "pull-sink-through": "0.0.0",
+        "pull-stream": "^3.4.0"
+      }
+    },
     "flumeview-reduce": {
       "version": "1.3.17",
       "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.17.tgz",
@@ -507,7 +4308,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -515,8 +4315,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -528,10 +4327,41 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "futoin-hkdf": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.3.tgz",
+      "integrity": "sha512-oR75fYk3B3X9/B02Y6vusrBKucrpC6VjxhRL+C6B7FwUpuSRHbhBNG3AZbcE/xPyJmEQWsyqUFp3VeNNbA3S7A=="
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -553,6 +4383,28 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-network2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/has-network2/-/has-network2-0.0.3.tgz",
+      "integrity": "sha512-EvEZguA+LkyiS8G/Qks5I6imKnM2Z3NPN3eoQhviUQ7O6/d8nyZ7sDozBk6kTIA+Qj/S/V8ubRA1rqJcxc3qBQ=="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -632,21 +4484,22 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.0.tgz",
-      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g==",
-      "dev": true
+      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g=="
     },
     "is-boolean-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
-      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==",
-      "dev": true
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ=="
     },
     "is-callable": {
       "version": "1.2.2",
@@ -677,16 +4530,47 @@
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
       "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
     },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
-      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+    },
+    "is-my-json-valid": {
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-my-ssb-valid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-my-ssb-valid/-/is-my-ssb-valid-1.1.0.tgz",
+      "integrity": "sha512-HAcl2v9tIkpjfVqaNgaqYWk2MW3WPZtj+XVpKUMgQRWEbLJdZ4orE5l9SJ5t+bQO1LB5rKeYGTlMfxSXEG1NTw==",
+      "requires": {
+        "is-my-json-valid": "^2.20.0",
+        "ssb-msg-content": "^1.0.1"
+      }
     },
     "is-negative-zero": {
       "version": "2.0.0",
@@ -696,8 +4580,12 @@
     "is-number-object": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-      "dev": true
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-regex": {
       "version": "1.1.1",
@@ -708,16 +4596,14 @@
       }
     },
     "is-set": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
-      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
     },
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -731,7 +4617,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
       "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.0",
         "es-abstract": "^1.17.4",
@@ -743,7 +4628,6 @@
           "version": "1.17.7",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
           "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -768,25 +4652,37 @@
     "is-weakmap": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "dev": true
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
     },
     "is-weakset": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
-      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw==",
-      "dev": true
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
     },
     "isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "json-buffer": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
       "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
+    },
+    "jsonpointer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
     },
     "level": {
       "version": "6.0.1",
@@ -891,6 +4787,11 @@
         "xtend": "~4.0.0"
       }
     },
+    "libnested": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/libnested/-/libnested-1.5.0.tgz",
+      "integrity": "sha512-IR5ASkAU4NHTN1JFeP9bYvhARhaBg8VD8yUcmvNIvFWg6L3dsM2yK1A9EM6MpPvWYKH9SEiljB59ZUa5s2pYnA=="
+    },
     "libsodium": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
@@ -904,6 +4805,17 @@
         "libsodium": "0.7.8"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -913,6 +4825,21 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "looper": {
       "version": "4.0.0",
@@ -931,6 +4858,19 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
+    "map-filter-reduce": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.2.2.tgz",
+      "integrity": "sha512-p+NIGQbEBxlw/qWwG+NME98G/9kjOQI70hmaH8QEZtIWfTmfMYLKQW4PJChP4izPHNAxlOfv/qefP0+2ZXn84A==",
+      "requires": {
+        "binary-search": "^1.2.0",
+        "compare-at-paths": "^1.0.0",
+        "pull-sink-through": "0.0.0",
+        "pull-sort": "^1.0.1",
+        "pull-stream": "^3.4.3",
+        "typewiselite": "^1.0.0"
+      }
     },
     "map-merge": {
       "version": "1.1.0",
@@ -956,8 +4896,8 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "monotonic-timestamp": {
-      "version": "github:staltz/mock-monotonic-timestamp#48396933b30b98d5eb096a259f80e5d975655e86",
-      "from": "github:staltz/mock-monotonic-timestamp"
+      "version": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86",
+      "from": "monotonic-timestamp@staltz/mock-monotonic-timestamp"
     },
     "moo": {
       "version": "0.5.1",
@@ -1059,8 +4999,7 @@
     "node-gyp-build": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-      "optional": true
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "non-private-ip": {
       "version": "1.4.4",
@@ -1070,18 +5009,24 @@
         "ip": "^1.1.5"
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
-      "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "object-keys": {
@@ -1090,12 +5035,12 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
       }
@@ -1109,6 +5054,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.2.tgz",
       "integrity": "sha512-c+EtVwT2IpXz5we2mR40aPLJ1s0eNOsxYeaYbaHhmsY6kWKo3IRkpwpBU5ck0aHfqfKUUEiKabC6rzsrG/hSHw=="
+    },
+    "on-change-network-strict": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-change-network-strict/-/on-change-network-strict-1.0.0.tgz",
+      "integrity": "sha512-ldHCpTJWgr5KUJy3/TVoSGNwBUA8BP9UFmd0iQqe4aGaXY4PJyzQPiVBIo8VBSlSoKyaJY3vcpW0hixZb6gPaA=="
+    },
+    "on-wakeup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz",
+      "integrity": "sha1-ANedmH3efIEXvudLtJA/b22vpSs="
     },
     "once": {
       "version": "1.4.0",
@@ -1142,6 +5097,12 @@
         "pull-through": "^1.0.17"
       }
     },
+    "parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1150,8 +5111,24 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "plur": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
       "dev": true
+    },
+    "pretty-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
+      }
     },
     "private-box": {
       "version": "0.3.1",
@@ -1160,6 +5137,22 @@
       "requires": {
         "chloride": "^2.2.9"
       }
+    },
+    "private-group-spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/private-group-spec/-/private-group-spec-1.0.0.tgz",
+      "integrity": "sha512-C4EJF39/13tKfUGbUzF/pgYTVNIOB6yWuWhz3IKTt4bmPeIG3EUAFsCsmk8E5x8Mzrg78fg2zpvstGoah11RHA=="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "promisify-4loc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promisify-4loc/-/promisify-4loc-1.0.0.tgz",
+      "integrity": "sha512-u/XtndUyqqDXAuhFEgFgkpjHG8IizREoj80j5dL4t41eE9yH0gzFPyOD21/VnikdPJtRziuqf6ryTu1HoTjyog=="
     },
     "promisify-tuple": {
       "version": "1.0.1",
@@ -1213,6 +5206,16 @@
         "ltgt": "^2.2.0",
         "pull-stream": "^3.6.0"
       }
+    },
+    "pull-defer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
+    },
+    "pull-flatmap": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pull-flatmap/-/pull-flatmap-0.0.1.tgz",
+      "integrity": "sha1-E9SURT6PbUeOe7+t5vj+AZf6a7c="
     },
     "pull-goodbye": {
       "version": "0.0.2",
@@ -1308,6 +5311,21 @@
         "looper": "^4.0.0"
       }
     },
+    "pull-pause": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/pull-pause/-/pull-pause-0.0.2.tgz",
+      "integrity": "sha1-GdRb6PqmFfpVbxSpb9czRiw3+6M="
+    },
+    "pull-ping": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.3.tgz",
+      "integrity": "sha512-nbY4yHnMesJBrvkbhMim4VXUC9k1VCkgrkQu49pf8mxFbmb/U2KQrsuePvSmLjRL+VgkBVRSUXUoOY7DtSvhKw==",
+      "requires": {
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.5",
+        "statistics": "^3.3.0"
+      }
+    },
     "pull-pushable": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
@@ -1325,6 +5343,20 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
       "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
+    },
+    "pull-sink-through": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
+      "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
+    },
+    "pull-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.2.tgz",
+      "integrity": "sha512-jGcAHMP+0Le+bEIhSODlbNNd3jW+S6XrXOlhVzfcKU5HQZjP92OzQSgHHSlwvWRsiTWi+UGgbFpL/5gGgmFoVQ==",
+      "requires": {
+        "pull-defer": "^0.2.3",
+        "pull-stream": "^3.6.9"
+      }
     },
     "pull-stream": {
       "version": "3.6.14",
@@ -1411,6 +5443,12 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "re-emitter": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
+      "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc=",
+      "dev": true
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -1455,6 +5493,12 @@
       "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
       "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
     },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1474,7 +5518,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true,
       "requires": {
         "through": "~2.3.4"
       }
@@ -1501,6 +5544,20 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "scuttle-testbot": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/scuttle-testbot/-/scuttle-testbot-1.5.0.tgz",
+      "integrity": "sha512-QCJLqhC1BH1gQWNOcaMki1ny/qRyld36NEY/0ddAGdF8/D7p6ACqer3iVou9Bc9YRgf23yxs8bZaCSzglmNhjA==",
+      "requires": {
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.14",
+        "rimraf": "^3.0.0",
+        "secret-stack": "^6.3.1",
+        "ssb-conn": "^0.19.1",
+        "ssb-db": "^20.3.0",
+        "ssb-keys": "^8.0.0"
+      }
     },
     "secret-handshake": {
       "version": "1.1.20",
@@ -1533,6 +5590,11 @@
         "to-camel-case": "^1.0.0"
       }
     },
+    "secret-stack-decorators": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/secret-stack-decorators/-/secret-stack-decorators-1.1.0.tgz",
+      "integrity": "sha512-wYl0Mcul/fuEbZwn9tN62c+W4LP2RPus/ilt3wdBNQqfBFSMlDXTLaIsrA4SEElb7JEBH4xzdQbOCnTvYHeWCA=="
+    },
     "seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
@@ -1560,7 +5622,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
       "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
-      "dev": true,
       "requires": {
         "es-abstract": "^1.18.0-next.0",
         "object-inspect": "^1.8.0"
@@ -1628,16 +5689,41 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
       "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
-      "optional": true,
       "requires": {
         "ini": "^1.3.5",
         "node-gyp-build": "^4.2.0"
+      }
+    },
+    "split": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+      "dev": true,
+      "requires": {
+        "through": "2"
       }
     },
     "split-buffer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
       "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "ssb-backlinks": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-2.1.1.tgz",
+      "integrity": "sha512-iv/B5EyjvNiKOeT3RkTuBRyU14GJ1sf5wnr07JOWeVI3OyNzedZ8z229yzZSaGHTYpbiSOcs9Z2CR8CkLQupQQ==",
+      "requires": {
+        "base64-url": "^2.3.3",
+        "flumeview-links": "^2.1.0",
+        "pull-stream": "^3.6.14",
+        "ssb-ref": "^2.14.0"
+      }
     },
     "ssb-caps": {
       "version": "1.1.0",
@@ -1678,6 +5764,128 @@
         }
       }
     },
+    "ssb-conn": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.19.1.tgz",
+      "integrity": "sha512-7HEiZPZyeIurrZsL1kxYgM164eNU+PRbqfhMzGNwQOrU5Ku+tciZhrZsbYtgNJHHIaoQQZfX79IaQQsD1ZrW5A==",
+      "requires": {
+        "debug": "~4.2.0",
+        "has-network2": ">=0.0.3",
+        "ip": "^1.1.5",
+        "on-change-network-strict": "1.0.0",
+        "on-wakeup": "^1.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-pause": "~0.0.2",
+        "pull-ping": "^2.0.3",
+        "pull-stream": "^3.6.14",
+        "secret-stack-decorators": "1.1.0",
+        "ssb-conn-db": "~0.3.3",
+        "ssb-conn-hub": "~0.2.7",
+        "ssb-conn-query": "~0.4.6",
+        "ssb-conn-staging": "~0.1.0",
+        "ssb-ref": "^2.14.2",
+        "ssb-typescript": "^2.1.0",
+        "statistics": "^3.3.0",
+        "zii": "~1.1.0"
+      }
+    },
+    "ssb-conn-db": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.3.3.tgz",
+      "integrity": "sha512-N2C/PweOlzEnrcfhGusnFhrZusfGyEMqip2WpQR/dgLAwHHQK8Wxn9KkC0457AHYlIO3UDH4Q1Mewsz8RLweMw==",
+      "requires": {
+        "atomic-file": "^2.1.1",
+        "debug": "~4.1.1",
+        "multiserver-address": "~1.0.1",
+        "pull-notify": "~0.1.1",
+        "ssb-ref": "~2.13.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ssb-ref": {
+          "version": "2.13.9",
+          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+          "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+          "requires": {
+            "ip": "^1.1.3",
+            "is-canonical-base64": "^1.1.1",
+            "is-valid-domain": "~0.0.1",
+            "multiserver-address": "^1.0.1"
+          }
+        }
+      }
+    },
+    "ssb-conn-hub": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.2.7.tgz",
+      "integrity": "sha512-fvX7HK44V65C8uMQhTK9B4SHZE7K5P0AU/cHVuDciKPNagEFV0QHKk//JnrrMKHKKvz1msKUxhA0S0iH0S4gqQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "ip": "^1.1.5",
+        "multiserver": "^3.4.0",
+        "multiserver-address": "~1.0.1",
+        "promisify-tuple": "^1.0.0",
+        "pull-cat": "~1.1.11",
+        "pull-notify": "~0.1.1",
+        "pull-stream": "~3.6.9",
+        "ssb-ref": "~2.13.9"
+      },
+      "dependencies": {
+        "ssb-ref": {
+          "version": "2.13.9",
+          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+          "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+          "requires": {
+            "ip": "^1.1.3",
+            "is-canonical-base64": "^1.1.1",
+            "is-valid-domain": "~0.0.1",
+            "multiserver-address": "^1.0.1"
+          }
+        }
+      }
+    },
+    "ssb-conn-query": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.6.tgz",
+      "integrity": "sha512-qwa0xYK4r3DwbJQQ/K5umw4VAt3aGTkRbFN0E43Mb33+M94jnXMhDIxZWrPoX1vVQSRZLlCb+laXQiGlxW32AQ==",
+      "requires": {
+        "ssb-conn-db": "~0.3.3",
+        "ssb-conn-hub": "~0.2.7",
+        "ssb-conn-staging": "~0.1.0"
+      }
+    },
+    "ssb-conn-staging": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-0.1.0.tgz",
+      "integrity": "sha512-bFtArSUiF3QrJ9LJ1auonC40pxJd58eBzozBiWsburwbZLUuxqrnW/kCaoyu+PYwTvc0FvMzZR/g4yL2wcE4Yw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "multiserver-address": "~1.0.1",
+        "pull-cat": "~1.1.11",
+        "pull-notify": "~0.1.1",
+        "pull-stream": "^3.6.9"
+      }
+    },
+    "ssb-crut": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ssb-crut/-/ssb-crut-2.1.2.tgz",
+      "integrity": "sha512-E8dO40XBVN+WmbTlsLHAmvcUjBNyWMOx+4qTU+/YTFbM/ZPLy/M8hoJ0IzRnOl1c3pglvyKkYVJXwWHBfYXo0Q==",
+      "requires": {
+        "@tangle/reduce": "^3.1.0",
+        "@tangle/strategy": "^2.0.1",
+        "is-my-ssb-valid": "^1.1.0",
+        "lodash.merge": "^4.6.2",
+        "pull-stream": "^3.6.14",
+        "ssb-schema-definitions": "^3.2.1"
+      }
+    },
     "ssb-db": {
       "version": "20.3.0",
       "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-20.3.0.tgz",
@@ -1707,8 +5915,8 @@
       },
       "dependencies": {
         "monotonic-timestamp": {
-          "version": "0.0.9",
-          "resolved": "github:staltz/mock-monotonic-timestamp#48396933b30b98d5eb096a259f80e5d975655e86"
+          "version": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86",
+          "from": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86"
         },
         "ssb-keys": {
           "version": "7.2.2",
@@ -1788,12 +5996,56 @@
       "resolved": "https://registry.npmjs.org/ssb-master/-/ssb-master-1.0.3.tgz",
       "integrity": "sha512-N1Cxm9WscGD9VEZrWbF2amyQai2U2g9gtq57W5zTqbhlQTLUUvl84U9A6fg6GPkECnUXadulnTw+mMYVkLLHjQ=="
     },
+    "ssb-msg-content": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-msg-content/-/ssb-msg-content-1.0.1.tgz",
+      "integrity": "sha512-M6W0Ef+jif829USmGvh6XeS4lYb/F2lgFhfEoCE/md7ESILNOGidp8frJE2uVOzSr2wVRA265tPrnVb7rYHkug=="
+    },
     "ssb-msgs": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "requires": {
         "ssb-ref": "^2.0.0"
+      }
+    },
+    "ssb-private1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-private1/-/ssb-private1-1.0.1.tgz",
+      "integrity": "sha512-x69YHNhjxCrknkK7XbEJyk2P0P3p52t6NF74I8ObHIrBdWnyRrO6iUH8K5b8CkaHawM4giXdZG5cyrOPzPN/Fg==",
+      "requires": {
+        "ssb-keys": "^7.2.2",
+        "ssb-ref": "^2.13.9"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "ssb-keys": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
+          "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
+          "requires": {
+            "chloride": "^2.2.8",
+            "mkdirp": "~0.5.0",
+            "private-box": "^0.3.0"
+          }
+        }
+      }
+    },
+    "ssb-query": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.5.tgz",
+      "integrity": "sha512-/QX6+DJkghqq1ZTbgYpOvaI+gx2O7ee1TRUM9yiOlVjh1XAQBevcBj0zO+W3TsNllX86urqBrySd/AEfFfUpIw==",
+      "requires": {
+        "explain-error": "^1.0.1",
+        "flumeview-query": "^8.0.0",
+        "pull-stream": "^3.6.2"
       }
     },
     "ssb-ref": {
@@ -1807,11 +6059,86 @@
         "multiserver-address": "^1.0.1"
       }
     },
+    "ssb-schema-definitions": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ssb-schema-definitions/-/ssb-schema-definitions-3.2.1.tgz",
+      "integrity": "sha512-+KBljo89bBi4gv3dnoiop4PexKLlySzq5bDcHvQ5aE4zXB8V33hocHuoJbihPr/jxry4kiqqo31TETwjV8YerQ==",
+      "requires": {
+        "lodash.clone": "^4.5.0",
+        "ssb-ref": "^2.14.0"
+      }
+    },
+    "ssb-tribes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-tribes/-/ssb-tribes-2.0.1.tgz",
+      "integrity": "sha512-qkzzlJ07pPXaAxh6XtH/eDTYbDV+daG7oPHGZOkvduS778v8b7nZxKnQgji+ZtnCEr3tbWVQGMsBC6SHc7JPZw==",
+      "requires": {
+        "@tangle/linear-append": "^1.0.0",
+        "@tangle/overwrite": "^2.0.1",
+        "@tangle/reduce": "^3.1.0",
+        "@tangle/strategy": "^2.0.1",
+        "charwise": "^3.0.1",
+        "envelope-js": "^1.0.0",
+        "envelope-spec": "^1.0.0",
+        "futoin-hkdf": "^1.3.2",
+        "is-my-ssb-valid": "^1.1.0",
+        "level": "^6.0.1",
+        "lodash.set": "^4.3.2",
+        "mkdirp": "^1.0.4",
+        "obz": "^1.0.3",
+        "private-group-spec": "^1.0.0",
+        "pull-level": "^2.0.4",
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.14",
+        "sodium-native": "^3.2.0",
+        "ssb-crut": "^2.1.2",
+        "ssb-keys": "^8.0.2",
+        "ssb-ref": "^2.14.3",
+        "ssb-schema-definitions": "^3.1.0"
+      },
+      "dependencies": {
+        "obz": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/obz/-/obz-1.0.3.tgz",
+          "integrity": "sha512-rH3U4eLHsV+OgkOS29ULiC9JLspwMCyCIH/+BglLPXDxQs13IK8AGD+nVmkGXqGN5JefZu85YhfIi05CsOKWPw=="
+        },
+        "ssb-keys": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.2.tgz",
+          "integrity": "sha512-u2U9t5YLbFShKQzr+ayMx9cYNvUJzDeOScodMwfP5zM3+/1AStvc5W91knZGllGwsmGjNC57KW+whRun+H/dBQ==",
+          "requires": {
+            "chloride": "~2.4.1",
+            "mkdirp": "~0.5.0",
+            "private-box": "~0.3.0"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            }
+          }
+        },
+        "ssb-ref": {
+          "version": "2.14.3",
+          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.14.3.tgz",
+          "integrity": "sha512-XhzVmezsUJLlKxTfWlicxhiPRTEYHfJLskYQNRSnw4USqgo9LVx53+MJAhdZOYpZTW2jINR0TeetWs9M27gcbA==",
+          "requires": {
+            "ip": "^1.1.3",
+            "is-canonical-base64": "^1.1.1",
+            "is-valid-domain": "~0.0.1",
+            "multiserver-address": "^1.0.1"
+          }
+        }
+      }
+    },
     "ssb-typescript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ssb-typescript/-/ssb-typescript-2.1.0.tgz",
-      "integrity": "sha512-UlnCQO4d24+bCoo7g6vXLipoCOnouPR6+ch+PT+BqvxwDJLJDdNDDWBH3g8GNJa6No2JoojNoubzpAStDBHgmg==",
-      "dev": true
+      "integrity": "sha512-UlnCQO4d24+bCoo7g6vXLipoCOnouPR6+ch+PT+BqvxwDJLJDdNDDWBH3g8GNJa6No2JoojNoubzpAStDBHgmg=="
     },
     "ssb-validate": {
       "version": "4.1.3",
@@ -1833,8 +6160,8 @@
           }
         },
         "monotonic-timestamp": {
-          "version": "0.0.9",
-          "resolved": "github:staltz/mock-monotonic-timestamp#48396933b30b98d5eb096a259f80e5d975655e86"
+          "version": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86",
+          "from": "git+ssh://git@github.com/staltz/mock-monotonic-timestamp.git#48396933b30b98d5eb096a259f80e5d975655e86"
         },
         "ssb-keys": {
           "version": "7.2.2",
@@ -1847,6 +6174,11 @@
           }
         }
       }
+    },
+    "statistics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz",
+      "integrity": "sha1-7HtHUP8DqySmTdmzV6eDFr6teKo="
     },
     "stream-to-pull-stream": {
       "version": "1.7.3",
@@ -1864,6 +6196,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -1878,7 +6218,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz",
       "integrity": "sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.0"
@@ -1902,14 +6241,6 @@
         "es-abstract": "^1.18.0-next.1"
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -1922,6 +6253,147 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tap-bail": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tap-bail/-/tap-bail-1.0.0.tgz",
+      "integrity": "sha1-xajMcRkfA3k4zVZ/l72jypcAGZo=",
+      "dev": true,
+      "requires": {
+        "tap-parser": "^5.3.3"
+      }
+    },
+    "tap-out": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-2.1.0.tgz",
+      "integrity": "sha512-LJE+TBoVbOWhwdz4+FQk40nmbIuxJLqaGvj3WauQw3NYYU5TdjoV3C0x/yq37YAvVyi+oeBXmWnxWSjJ7IEyUw==",
+      "dev": true,
+      "requires": {
+        "re-emitter": "1.1.3",
+        "readable-stream": "2.2.9",
+        "split": "1.0.0",
+        "trim": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "dev": true,
+          "requires": {
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "tap-parser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+      "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+      "dev": true,
+      "requires": {
+        "events-to-array": "^1.0.1",
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true,
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "tap-spec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-5.0.0.tgz",
+      "integrity": "sha512-zMDVJiE5I6Y4XGjlueGXJIX2YIkbDN44broZlnypT38Hj/czfOXrszHNNJBF/DXR8n+x6gbfSx68x04kIEHdrw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "duplexer": "^0.1.1",
+        "figures": "^1.4.0",
+        "lodash": "^4.17.10",
+        "pretty-ms": "^2.1.0",
+        "repeat-string": "^1.5.2",
+        "tap-out": "^2.1.0",
+        "through2": "^2.0.0"
+      }
     },
     "tape": {
       "version": "5.0.1",
@@ -1975,8 +6447,61 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "to-camel-case": {
       "version": "1.0.0",
@@ -1999,6 +6524,12 @@
         "to-no-case": "^1.0.0"
       }
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -2017,6 +6548,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
       "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
+    },
+    "typewiselite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+      "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
     },
     "uint48be": {
       "version": "2.0.1",
@@ -2037,7 +6573,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
       "integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
-      "dev": true,
       "requires": {
         "is-bigint": "^1.0.0",
         "is-boolean-object": "^1.0.0",
@@ -2050,7 +6585,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
       "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dev": true,
       "requires": {
         "is-map": "^2.0.1",
         "is-set": "^2.0.1",
@@ -2062,7 +6596,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
       "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.2",
         "es-abstract": "^1.17.5",
@@ -2076,7 +6609,6 @@
           "version": "1.17.7",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
           "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -2150,6 +6682,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/zerr/-/zerr-1.0.4.tgz",
       "integrity": "sha1-YoFN15nv+DYfKiKPQfcFxeGd5Mk="
+    },
+    "zii": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/zii/-/zii-1.1.1.tgz",
+      "integrity": "sha512-nOC9WLdEOvBFoxbuc/iHZ0bsudW/nUBOLQK3hQRfp/TD3/pyQoWpBKJlmd11GgHLQEVRp2KemIeHQcBHQJx/DA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,16 @@
     "promisify-4loc": "1.0.0",
     "rimraf": "^3.0.2",
     "secret-stack": "6.3.1",
+    "ssb-backlinks": "2.1.1",
     "ssb-caps": "1.1.0",
     "ssb-config": "3.4.5",
     "ssb-db": "20.3.0",
     "ssb-keys": "8.0.0",
     "ssb-logging": "1.0.0",
     "ssb-master": "1.0.3",
+    "ssb-private1": "1.0.1",
+    "ssb-query": "2.4.5",
+    "ssb-tribes": "0.4.1",
     "yargs": "^16.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ssb-master": "1.0.3",
     "ssb-private1": "1.0.1",
     "ssb-query": "2.4.5",
-    "ssb-tribes": "0.4.1",
+    "ssb-tribes": "^2.0.1",
     "yargs": "^16.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "monotonic-timestamp": "staltz/mock-monotonic-timestamp",
     "promisify-4loc": "1.0.0",
     "rimraf": "^3.0.2",
+    "scuttle-testbot": "ssbc/scuttle-testbot#folderopt",
     "secret-stack": "6.3.1",
     "ssb-backlinks": "2.1.1",
     "ssb-caps": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "monotonic-timestamp": "staltz/mock-monotonic-timestamp",
     "promisify-4loc": "1.0.0",
     "rimraf": "^3.0.2",
-    "scuttle-testbot": "ssbc/scuttle-testbot#folderopt",
+    "scuttle-testbot": "1.5.0",
     "secret-stack": "6.3.1",
     "ssb-backlinks": "2.1.1",
     "ssb-caps": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "compile": "tsc",
     "pretest": "npm run compile",
-    "test": "tape test/*.js"
+    "test": "tape test/*.js | tap-spec"
   },
   "repository": {
     "url": "https://github.com/staltz/ssb-fixtures"
@@ -33,6 +33,7 @@
     "ssb-private1": "1.0.1",
     "ssb-query": "2.4.5",
     "ssb-tribes": "0.4.1",
+    "tap-spec": "^5.0.0",
     "yargs": "^16.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "compile": "tsc",
     "pretest": "npm run compile",
-    "test": "tape test/*.js | tap-spec"
+    "test": "tape test/*.js | tap-bail | tap-spec"
   },
   "repository": {
     "url": "https://github.com/staltz/ssb-fixtures"
@@ -33,7 +33,6 @@
     "ssb-private1": "1.0.1",
     "ssb-query": "2.4.5",
     "ssb-tribes": "0.4.1",
-    "tap-spec": "^5.0.0",
     "yargs": "^16.1.0"
   },
   "devDependencies": {
@@ -44,6 +43,8 @@
     "pull-stream": "3.6.14",
     "ssb-ref": "2.14.2",
     "ssb-typescript": "^2.1.0",
+    "tap-bail": "^1.0.0",
+    "tap-spec": "^5.0.0",
     "tape": "^5.0.1",
     "typescript": "^4.0.3"
   },

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,5 +6,6 @@ export const AUTHORS = 150;
 export const SLIM = true;
 export const REPORT = true;
 export const VERBOSE = false;
+export const REPLICATION_TIMESTAMP = 1610040172000;
 export const randomSeed = generateRandomSeed;
 export const outputDir = () => path.join(process.cwd(), 'data');

--- a/src/frequencies.ts
+++ b/src/frequencies.ts
@@ -51,6 +51,20 @@ export = {
   POST_MENTIONS_FREQUENCY: 0.6,
 
   /**
+   * Distribution of "private threads" versus "private groups (tribes)".
+   * Not based on real world data because we (as of 2020-12) don't have
+   * tribes deployed in production.
+   *
+   * Normalized.
+   */
+  PRIVATE_FREQUENCIES: {
+    direct_message: 0.7,
+    tribe_creation: 0.05,
+    tribe_invitation: 0.1,
+    tribe_message: 0.15,
+  },
+
+  /**
    * Distribution of types of mentions in msgs of type 'post'.
    * Based on staltz's intuition.
    * FIXME: base this on analysis of real world data

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -176,7 +176,7 @@ async function generatePrivate(
     const inviteeIds: Array<FeedId> = paretoSampleMany(
       seed,
       authors.map((a) => a.id),
-      randomInt(seed, 1, 15),
+      randomInt(seed, 2, 15),
       [author.id], // add author.id to force others to be different
     );
     inviteeIds.shift(); // remove author.id

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import pify = require('promisify-4loc');
 import {ContactContent, Msg} from 'ssb-typescript';
 import {makeSSB} from './ssb';
 import {generateAuthors, generateMsgOrContent} from './generate';
-import {Opts, MsgsByType, Follows, Blocks, TribesByAuthor, Peer} from './types';
+import {Opts, MsgsByType, Follows, Blocks, Peer} from './types';
 import {paretoSample} from './sample';
 import slimify from './slimify';
 import writeReportFile from './report';
@@ -58,7 +58,6 @@ export = async function generateFixture(opts?: Partial<Opts>) {
   const peers = [mainPeer, ...otherPeers];
   const msgs: Array<Msg> = [];
   const msgsByType: MsgsByType = {};
-  const tribesByAuthor: TribesByAuthor = new Map();
   const peersById = new Map(peers.map((p) => [p.id, p]));
 
   const follows: Follows = new Map(peers.map((a) => [a.id, new Set()]));
@@ -89,7 +88,6 @@ export = async function generateFixture(opts?: Partial<Opts>) {
       peer,
       msgsByType,
       peers,
-      tribesByAuthor,
       follows,
       blocks,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import writeReportFile from './report';
 import * as defaults from './defaults';
 import fs = require('fs');
 import path = require('path');
+const mkdirp = require('mkdirp');
 const TestBot = require('scuttle-testbot');
 const __ts = require('monotonic-timestamp');
 
@@ -27,6 +28,7 @@ function saveSecret(
   filename: string = 'secret',
 ) {
   if (!keys) return;
+  mkdirp.sync(outputDir);
   const filePath = path.join(outputDir, filename);
   const fileContent = JSON.stringify(keys, null, 2);
   fs.writeFileSync(filePath, fileContent, {encoding: 'utf-8'});

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,11 +1,11 @@
 import fs = require('fs');
 import path = require('path');
 import {FeedId, Msg} from 'ssb-typescript';
-import {Author, Blocks, Follows, MsgsByType} from './types';
+import {Peer, Blocks, Follows, MsgsByType} from './types';
 
 function calculateMsgsByHops(
   msgs: Array<Msg>,
-  authors: Array<Author>,
+  authors: Array<Peer>,
   follows: Follows,
 ) {
   const self = authors[0];
@@ -49,7 +49,7 @@ function calculateMsgsByHops(
 function* produceReport(
   msgs: Array<Msg>,
   msgsByType: MsgsByType,
-  authors: Array<Author>,
+  authors: Array<Peer>,
   follows: Follows,
 ) {
   const self = authors[0];
@@ -81,7 +81,7 @@ function* produceReport(
 export default function writeReportFile(
   msgs: Array<Msg>,
   msgsByType: MsgsByType,
-  authors: Array<Author>,
+  authors: Array<Peer>,
   follows: Follows,
   outputDir: string,
 ) {

--- a/src/sample.ts
+++ b/src/sample.ts
@@ -43,6 +43,25 @@ export function paretoSample<T>(
   return arr[i];
 }
 
+export function paretoSampleMany<T>(
+  seed: string,
+  pool: Array<T>,
+  targetSize: number,
+  target: Array<T> = [],
+  shapeParam: number = 2,
+  min: number = 0,
+) {
+  const quantity = Math.min(targetSize, pool.length);
+  while (target.length < quantity) {
+    let other: T;
+    do {
+      other = paretoSample(seed, pool, shapeParam, min);
+    } while (target.some((x) => other === x));
+    target.push(other);
+  }
+  return target;
+}
+
 export function uniformSample<T>(seed: string, arr: Array<T>): T {
   const i = Math.floor(random(seed) * arr.length);
   return arr[i];

--- a/src/ssb.ts
+++ b/src/ssb.ts
@@ -1,6 +1,7 @@
 const TestBot = require('scuttle-testbot');
 
 export function makeSSB(keys: any, path?: string): any {
+  const safeFeedId = (id: string) => id.slice(1, -9).replace(/[\+\/\.]/g, '');
   return TestBot.use(require('ssb-master'))
     .use(require('ssb-logging'))
     .use(require('ssb-backlinks'))
@@ -9,8 +10,9 @@ export function makeSSB(keys: any, path?: string): any {
     .use(require('ssb-private1'))
     .call(null, {
       keys,
+      name: 'ssb-fixtures-' + safeFeedId(keys.id),
       path,
-      startUnclean: true,
+      startUnclean: path ? true : false,
       logging: {
         level: 'info',
       },

--- a/src/ssb.ts
+++ b/src/ssb.ts
@@ -1,48 +1,22 @@
-const SecretStack = require('secret-stack');
-const makeConfig = require('ssb-config/inject');
-import fs = require('fs');
-import path = require('path');
+const TestBot = require('scuttle-testbot');
 
-export function makeSSB(authorsKeys: Array<any>, outputDir: string): any {
-  const hops0Keys = authorsKeys[0];
-
-  const peer = SecretStack({appKey: require('ssb-caps').shs})
-    .use(require('ssb-master'))
+export function makeSSB(keys: any, path?: string): any {
+  return TestBot.use(require('ssb-master'))
     .use(require('ssb-logging'))
-    .use(require('ssb-db'))
     .use(require('ssb-backlinks'))
     .use(require('ssb-query'))
     .use(require('ssb-tribes'))
     .use(require('ssb-private1'))
-    .call(
-      null,
-      makeConfig('ssb', {
-        path: outputDir,
-        keys: hops0Keys,
-        logging: {
-          level: 'info',
-        },
-        connections: {
-          incoming: {},
-          outgoing: {},
-        },
-      }),
-    );
-
-  saveSecret(hops0Keys, outputDir);
-
-  if (authorsKeys[1]) saveSecret(authorsKeys[1], outputDir, 'secret-b');
-  if (authorsKeys[2]) saveSecret(authorsKeys[2], outputDir, 'secret-c');
-
-  return peer;
-}
-
-function saveSecret(
-  keys: unknown,
-  outputDir: string,
-  filename: string = 'secret',
-) {
-  const filePath = path.join(outputDir, filename);
-  const fileContent = JSON.stringify(keys, null, 2);
-  fs.writeFileSync(filePath, fileContent, {encoding: 'utf-8'});
+    .call(null, {
+      keys,
+      path,
+      startUnclean: true,
+      logging: {
+        level: 'info',
+      },
+      connections: {
+        incoming: {},
+        outgoing: {},
+      },
+    });
 }

--- a/src/ssb.ts
+++ b/src/ssb.ts
@@ -10,6 +10,10 @@ export function makeSSB(authorsKeys: Array<any>, outputDir: string): any {
     .use(require('ssb-master'))
     .use(require('ssb-logging'))
     .use(require('ssb-db'))
+    .use(require('ssb-backlinks'))
+    .use(require('ssb-query'))
+    .use(require('ssb-tribes'))
+    .use(require('ssb-private1'))
     .call(
       null,
       makeConfig('ssb', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,12 @@ export type Peer = {
   publish: (x: any, cb: (err: any, val: any) => void) => void;
   close: (cb?: (err: any, val: any) => void) => void;
   tribes: {
-    [k: string]: any;
+    list: (cb: (err: any, val: string[]) => void) => void;
+    create: () => any;
+    invite: (x: any) => any;
   };
   id: FeedId;
 };
 
-export type TribesByAuthor = Map<FeedId, Set<GroupIp>>;
 export type Follows = Map<FeedId, Set<FeedId>>;
 export type Blocks = Map<FeedId, Set<FeedId>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,12 @@ export type MsgType = keyof typeof freq.MSG_TYPE_FREQUENCIES;
 
 export type MsgsByType = Partial<Record<MsgType, Array<Msg>>>;
 
-export type Author = {
-  add: CallableFunction;
+export type Peer = {
+  publish: (x: any, cb: (err: any, val: any) => void) => void;
+  close: (cb?: (err: any, val: any) => void) => void;
+  tribes: {
+    [k: string]: any;
+  };
   id: FeedId;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type Opts = {
   verbose: boolean;
 };
 
+export type GroupIp = string;
+
 export type MsgType = keyof typeof freq.MSG_TYPE_FREQUENCIES;
 
 export type MsgsByType = Partial<Record<MsgType, Array<Msg>>>;
@@ -21,5 +23,6 @@ export type Author = {
   id: FeedId;
 };
 
+export type TribesByAuthor = Map<FeedId, Set<GroupIp>>;
 export type Follows = Map<FeedId, Set<FeedId>>;
 export type Blocks = Map<FeedId, Set<FeedId>>;

--- a/test/fixtures/deterministic/0.json
+++ b/test/fixtures/deterministic/0.json
@@ -1,5 +1,5 @@
 {
-  "key": "%ctqwAmcFfotUvtBSvS1x/ux7CZY7PkbkVkKEdkEvvwM=.sha256",
+  "key": "%M6Pc3/gFOkRsC0ptBai79T5SRbsdB6f6ze7+5NVMX9c=.sha256",
   "value": {
     "previous": null,
     "sequence": 1,
@@ -8,9 +8,20 @@
     "hash": "sha256",
     "content": {
       "type": "post",
-      "text": "OLDESTMSG Nisi sunt duis elit cupidatat aliquip. Enim quis tempor anim ullamco est fugiat laborum laborum proident ex minim eu amet. Quis nulla velit enim deserunt irure ipsum veniam ad ullamco."
+      "text": "OLDESTMSG Et sunt aliqua aliquip ex. Dolore nulla ut qui dolor. Incididunt qui dolor ipsum aliqua aliquip proident proident. Nisi sunt duis elit cupidatat aliquip. Enim quis tempor anim ullamco est fugiat laborum laborum proident ex minim eu amet. Quis nulla velit enim deserunt irure ipsum veniam ad ullamco.",
+      "mentions": [
+        {
+          "link": "&ZHVpc3BhcmlhdHVyYWxpcXVhdm9sdXB0YXRlZnVnaWE=.sha256",
+          "type": "image/png",
+          "size": 623621
+        },
+        {
+          "link": "@k2M2dnNL5YOtmoHkGGpVq5QM5WOLCP7N3EOY9u3Hk+I=.ed25519",
+          "name": "ut eu quis"
+        }
+      ]
     },
-    "signature": "B1+WFse9WiixIxb4tioK5YhprWHTycIz8fyjznheCjDaSu6edw2CBrYFRgA0LmZVKC7vN6xyftMMFMJRB5HyAg==.sig.ed25519"
+    "signature": "nq63ViBnUjMVr1y7Y3jlJrj3R2yLG2ztM1WdhYEtwuXzj8YA0jvevoNxuQrZOYt8/8DQU6XZG8bwRI3mxhGOBA==.sig.ed25519"
   },
   "timestamp": 1438787145000
 }

--- a/test/fixtures/deterministic/1.json
+++ b/test/fixtures/deterministic/1.json
@@ -1,5 +1,5 @@
 {
-  "key": "%8VrSfeEOCNl3XwFl3okW6632XGXK4Ld8x8GuYoM9IDo=.sha256",
+  "key": "%4NfIMAwKtebB4Ml4oyeHg6TA5XgA2NIpqd0tgpytHKE=.sha256",
   "value": {
     "previous": null,
     "sequence": 1,
@@ -7,14 +7,10 @@
     "timestamp": 1438787265000,
     "hash": "sha256",
     "content": {
-      "type": "vote",
-      "vote": {
-        "link": "%ctqwAmcFfotUvtBSvS1x/ux7CZY7PkbkVkKEdkEvvwM=.sha256",
-        "value": 1,
-        "expression": "y"
-      }
+      "type": "post",
+      "text": "Aliqua adipisicing ea esse proident labore velit esse elit nulla. In excepteur dolore aliquip deserunt adipisicing magna et excepteur. Pariatur proident qui ad. Ex consectetur adipisicing officia qui velit. Nostrud velit officia aute enim aute do commodo ad culpa Lorem."
     },
-    "signature": "JVV1lqWYUvS20SHT5I/rrN89AXW7Cuzr6/17SEGJfqMY+FyRe1kozFU5mKc/lqUxMWYorfqO+SsJGY/6afV7Aw==.sig.ed25519"
+    "signature": "yiK28H7dU2UArupmK6AW3q3QhVwfqH8Tr+U1afNrdc1bXewAyzCKD/xddjZ2hBnGsW/e7OAvFqX2cF2ZCuW0AQ==.sig.ed25519"
   },
-  "timestamp": 1438787385000
+  "timestamp": 1610040172000
 }

--- a/test/fixtures/deterministic/2.json
+++ b/test/fixtures/deterministic/2.json
@@ -1,17 +1,36 @@
 {
-  "key": "%CfkI9X/AZzG9mrwaRQvVg9D2fPDw4K9e78xuoNiQhqQ=.sha256",
+  "key": "%zrRED8BwMyIuTvSDO56E91YIo0xe3fDjrH185Z+M7wY=.sha256",
   "value": {
-    "previous": "%ctqwAmcFfotUvtBSvS1x/ux7CZY7PkbkVkKEdkEvvwM=.sha256",
+    "previous": "%M6Pc3/gFOkRsC0ptBai79T5SRbsdB6f6ze7+5NVMX9c=.sha256",
     "sequence": 2,
     "author": "@k2M2dnNL5YOtmoHkGGpVq5QM5WOLCP7N3EOY9u3Hk+I=.ed25519",
     "timestamp": 1438787505000,
     "hash": "sha256",
     "content": {
       "type": "post",
-      "text": "LATESTMSG Nostrud velit officia aute enim. Do commodo ad culpa Lorem laboris velit. Exercitation sit ut eu quis sunt cillum incididunt. Dolor est mollit duis pariatur aliqua voluptate fugiat ad id. Magna minim enim dolor quis et sunt aliqua aliquip ex anim dolore nulla ut.\nExcepteur sunt culpa incididunt quis ea aliqua sit proident. Deserunt nulla tempor aute esse aliquip. Do et magna eu aliqua adipisicing ea esse proident labore velit esse elit. In in excepteur dolore. Deserunt adipisicing magna et excepteur et pariatur proident qui ad aliquip ex consectetur adipisicing officia qui.",
-      "channel": "ad"
+      "text": "LATESTMSG Quis ea aliqua sit proident exercitation. Nulla tempor aute esse.",
+      "mentions": [
+        {
+          "link": "@k2M2dnNL5YOtmoHkGGpVq5QM5WOLCP7N3EOY9u3Hk+I=.ed25519",
+          "name": "proident"
+        },
+        {
+          "link": "@CTlYy3ZwIkt4qbB/bIQ7SndWzt8gDM9deKLWwDwbwL8=.ed25519",
+          "name": "id ipsum officia"
+        },
+        {
+          "link": "@CTlYy3ZwIkt4qbB/bIQ7SndWzt8gDM9deKLWwDwbwL8=.ed25519",
+          "name": "qui reprehenderit"
+        },
+        {
+          "link": "&bnVsbGFkZXNlcnVudGFsaXF1aXB2ZW5pYW1hbWV0aXI=.sha256",
+          "type": "image/png",
+          "size": 627426,
+          "name": "sint dolor reprehenderit"
+        }
+      ]
     },
-    "signature": "kM2XnH56+Z4SNOGGED/gdo6W4nM+9sVHIFpHX/MY/OxMK0j6/hZvdWWKTnHFaANmsVV8H3f5rTecsBsTxw1MCQ==.sig.ed25519"
+    "signature": "K/sRZsbqKulhdmVOQ9FndDNlqi+LKdzR7BWzdiVbuHeo0ccNg68CRF4uyfOAEXG7HFmdPKcRi4YiPovbkfIJBw==.sig.ed25519"
   },
   "timestamp": 1438787625000
 }

--- a/test/fixtures/deterministic/3-extension.json
+++ b/test/fixtures/deterministic/3-extension.json
@@ -1,7 +1,7 @@
 {
-  "key": "%XBlLX9wsG9+KnMcQltlUlCMTbai4QzplOrO6lGO/VAo=.sha256",
+  "key": "%AfZmsCavWVCLK4Oivu92UqGUgq8jQG78a76vXJ/nqBU=.sha256",
   "value": {
-    "previous": "%CfkI9X/AZzG9mrwaRQvVg9D2fPDw4K9e78xuoNiQhqQ=.sha256",
+    "previous": "%zrRED8BwMyIuTvSDO56E91YIo0xe3fDjrH185Z+M7wY=.sha256",
     "sequence": 3,
     "author": "@k2M2dnNL5YOtmoHkGGpVq5QM5WOLCP7N3EOY9u3Hk+I=.ed25519",
     "timestamp": 1438787745000,
@@ -9,9 +9,9 @@
     "content": {
       "type": "contact",
       "contact": "@CTlYy3ZwIkt4qbB/bIQ7SndWzt8gDM9deKLWwDwbwL8=.ed25519",
-      "blocking": true
+      "following": true
     },
-    "signature": "vJgB0nnWe1LIBQyDj/3J0zZgINuwxp+M0fPTD5DsQp9AaJTYGhxLNo139pJJGZYUilcExehyB1WNmJydgOUODg==.sig.ed25519"
+    "signature": "LNB7xyxsUizrnxjLRazlSZBvhLaaRBUdOKYhBbhGpjxxz19sD3x/jagOkUG9fGEFb1NnPKntNf+PV9ELktrRAw==.sig.ed25519"
   },
   "timestamp": 1438787865000
 }

--- a/test/fixtures/deterministic/4-extension.json
+++ b/test/fixtures/deterministic/4-extension.json
@@ -1,24 +1,17 @@
 {
-  "key": "%zR0NVXYhVvx8oE84Uch1BDnecwA+rzsKjOhu8cFs3tU=.sha256",
+  "key": "%b9n1i/wiLaoUBQIXOxHx7VVTDmWpOgcbSxB9FDyuFlQ=.sha256",
   "value": {
-    "previous": "%XBlLX9wsG9+KnMcQltlUlCMTbai4QzplOrO6lGO/VAo=.sha256",
+    "previous": "%AfZmsCavWVCLK4Oivu92UqGUgq8jQG78a76vXJ/nqBU=.sha256",
     "sequence": 4,
     "author": "@k2M2dnNL5YOtmoHkGGpVq5QM5WOLCP7N3EOY9u3Hk+I=.ed25519",
     "timestamp": 1438787985000,
     "hash": "sha256",
     "content": {
       "type": "post",
-      "text": "Sint ullamco ea veniam adipisicing minim excepteur pariatur amet dolore occaecat sunt voluptate sunt. Adipisicing ea occaecat dolore id id laborum tempor ut Lorem. Ad anim minim dolor sint dolor reprehenderit reprehenderit consectetur laborum adipisicing. Nulla deserunt aliquip veniam amet irure dolor incididunt sint minim qui reprehenderit.",
-      "channel": "consectetur",
-      "mentions": [
-        {
-          "link": "&YWxpcXVhbnVsbGFhbGlxdWFwYXJpYXR1cnByb2lkZW4=.sha256",
-          "type": "image/png",
-          "size": 398160
-        }
-      ]
+      "text": "Cillum Lorem et ut incididunt veniam ut. Culpa irure tempor consectetur ut cillum. Ad eu do eiusmod laborum anim aliquip in. Non aute ea in. Nulla aliqua pariatur proident cillum cupidatat irure consequat nisi ad deserunt consectetur dolore sint ullamco ea. Adipisicing minim excepteur pariatur. Dolore occaecat sunt voluptate sunt qui adipisicing.\nId ea aliqua esse minim irure eiusmod mollit velit occaecat anim. Cupidatat reprehenderit esse Lorem culpa magna ad pariatur. Excepteur tempor incididunt dolore laborum nisi ea nostrud mollit. Esse culpa aliqua culpa consectetur ea. Irure in Lorem id. Consectetur reprehenderit magna aute in non sit exercitation.",
+      "channel": "voluptate"
     },
-    "signature": "I51ik4+38w8wNjQwEkqxwYw9SFW+tTOUYsWP9pVVha6TDZ9QmdL4zItVq7KTvG/Q4gQEmi/pFiobbvVfYBOJBg==.sig.ed25519"
+    "signature": "R+fOJUuT4sJTVIE7iKKop3goI8K/xWVE89aqVHYZ1/EnPr+oGTHPQYFbyb9ZPaAHMv8/MSGqwOs7+MvOTLggDA==.sig.ed25519"
   },
   "timestamp": 1438788105000
 }

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,7 @@ function generateAndTest(opts, cb) {
           });
         }
         const msgs = arr.map((x) => x.value);
+        msgs.sort((a, b) => a.value.timestamp - b.value.timestamp);
         cb(err, msgs, cleanup);
       }),
     );
@@ -115,11 +116,36 @@ test('marks first and last msg as OLDESTMSG and LATESTMSG', (t) => {
   );
 });
 
-test('can generate about msgs', (t) => {
+test('can generate vote msgs', (t) => {
   generateAndTest(
     {
       outputDir: 'ssb-fixtures-test-3',
-      seed: 'rosette',
+      seed: 'dog4',
+      messages: 4,
+      authors: 1,
+    },
+    (err, msgs, cleanup) => {
+      t.error(err, 'no error');
+      t.equals(msgs.length, 4, 'there are 4 msgs');
+
+      const m = msgs[1];
+      t.equals(m.value.content.type, 'vote', '2nd msg is an about');
+      t.equals(m.value.content.vote.value, 1, 'vote.value is 1');
+      t.equals(m.value.content.vote.expression, 'y', 'vote.expression');
+      t.true(Ref.isMsg(m.value.content.vote.link), 'vote.link');
+
+      cleanup(() => {
+        t.end();
+      });
+    },
+  );
+});
+
+test('can generate about msgs', (t) => {
+  generateAndTest(
+    {
+      outputDir: 'ssb-fixtures-test-4',
+      seed: 'dog2',
       messages: 5,
       authors: 1,
     },
@@ -128,8 +154,8 @@ test('can generate about msgs', (t) => {
       t.equals(msgs.length, 5, 'there are 5 msgs');
 
       t.equals(msgs[3].value.content.type, 'about', '4th msg is an about');
-      t.equals(typeof msgs[3].value.content.image, 'object', '"image" object');
-      t.true(Ref.isBlob(msgs[3].value.content.image.link), 'link is blob');
+      t.equals(msgs[3].value.content.name, 'magna esse', 'contains name');
+      t.true(Ref.isBlob(msgs[3].value.content.image), 'contains image');
 
       cleanup(() => {
         t.end();
@@ -141,15 +167,15 @@ test('can generate about msgs', (t) => {
 test('can generate tribes', (t) => {
   generateAndTest(
     {
-      outputDir: 'ssb-fixtures-test-4',
-      seed: 'dog8',
+      outputDir: 'ssb-fixtures-test-5',
+      seed: 'apple',
       messages: 5,
       authors: 3,
     },
     (err, msgs, cleanup) => {
       t.error(err, 'no error');
-      t.equals(typeof msgs[3].value.content, 'string', '4th msg is encrypted');
-      t.true(msgs[3].value.content.endsWith('.box2'), 'encrypted with box2');
+      t.equals(typeof msgs[2].value.content, 'string', '3rd msg is encrypted');
+      t.true(msgs[2].value.content.endsWith('.box2'), 'encrypted with box2');
       cleanup(() => {
         t.end();
       });

--- a/test/index.js
+++ b/test/index.js
@@ -138,10 +138,29 @@ test('can generate about msgs', (t) => {
   );
 });
 
-test('latestmsg and same seed can continue generating', (t) => {
+test('can generate tribes', (t) => {
   generateAndTest(
     {
       outputDir: 'ssb-fixtures-test-4',
+      seed: 'dog8',
+      messages: 5,
+      authors: 3,
+    },
+    (err, msgs, cleanup) => {
+      t.error(err, 'no error');
+      t.equals(typeof msgs[3].value.content, 'string', '4th msg is encrypted');
+      t.true(msgs[3].value.content.endsWith('.box2'), 'encrypted with box2');
+      cleanup(() => {
+        t.end();
+      });
+    },
+  );
+});
+
+test('latestmsg and same seed can continue generating', (t) => {
+  generateAndTest(
+    {
+      outputDir: 'ssb-fixtures-test-5',
       seed: 'deterministic',
       messages: 5,
       authors: 2,


### PR DESCRIPTION
@arj03 @cryptix @mixmix I think fixtures now can generate: (1) tribe creation, (2) tribe invitation to other feeds, (3) post a message inside tribes, all using `ssb-tribes`. *I think* it's working, but it would be good to be sure.

How to test this out: 

- `git clone`
- checkout branch `tribes`
- `npm install`
- `npm run compile`
- `node lib/bin.js`
- check `./data` dir when it's done

Note, you can get the `secret` of the 3 most popular feeds, they are in the generated `./data/`.