### PR TITLE
Update msg type frequencies

### DIFF
--- a/src/frequencies.ts
+++ b/src/frequencies.ts
@@ -10,17 +10,12 @@ export = {
    * Not normalized.
    */
   MSG_TYPE_FREQUENCIES: {
-    vote: 269447,
-    post: 173264,
-    contact: 167326,
-    private: 93208,
-    // channel: 57087,
-    about: 33476,
-    // chess_move: 24199,
-    // pub: 17646,
-    // 'image/jpeg': 10681,
-    // 'git-update': 8915,
-    // 'image/png': 5809,
+    vote: 291505,
+    post: 168091,
+    contact: 59912,
+    private: 82034,
+    about: 11528,
+    other: 62462
   },
 
   /**


### PR DESCRIPTION
I was a bit puzzled by the numbers we got from netsim friday because they didn't match with with the earlier partial replication results I had from my browser testing. I ran some new numbers and updated the source of the frequencies. Basically the numbers before were skewed because they were from a world with a lot more pubs in the social graph, so they inflate the `contact` numbers. Another thing is that the frequencies before did not properly account for `other` types. These are roughly 10%, so significant enough to include especially for our partial replication tests. I believe with this change and the blocking bug from https://github.com/ssb-ngi-pointer/ssb-replication-scheduler/pull/5#issuecomment-938392938 fixed we should get a lot better numbers.

Sorry for the lateness of this message, it was just bugging me, so had to get it out of my system :)